### PR TITLE
Clarify "non-query static analysis" out-of-scope wording in docs

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -1,0 +1,117 @@
+# Pydantree Concept
+
+## Vision
+
+Pydantree should be the **user-facing Python side** of Neovim-style Tree-sitter query workflows.
+
+The library's purpose is to let users describe query objects and match results as Pydantic models, execute queries in a conceptually simple way (wrapping Tree-sitter CLI flows), and consume typed JSON-equivalent data in Python.
+
+## Why This Direction
+
+The previous direction mixed many concerns (views, transformations, graph analysis, etc.).
+This concept intentionally narrows scope to improve clarity and long-term maintainability:
+
+- one primary abstraction model,
+- one query execution model,
+- one output style.
+
+## Product Definition
+
+Pydantree is:
+
+1. **Pydantic schemas for Tree-sitter query interactions**
+   - query specification models,
+   - capture/match/event models,
+   - normalized result envelope models.
+
+2. **A Pythonic Neovim Tree-sitter query API**
+   - familiar naming and behavior for query/capture handling,
+   - ergonomic helpers for common operations,
+   - explicit, inspectable model objects.
+
+3. **A wrapper over Tree-sitter CLI execution**
+   - thin process-invocation layer,
+   - deterministic mapping from CLI output into models,
+   - minimal hidden magic.
+
+Pydantree is **not**:
+
+- a graph library,
+- a general AST analytics platform,
+- a complex transformation framework.
+
+## Scope Boundaries
+
+### In Scope
+
+- Query authoring and validation via Pydantic.
+- Running queries against source files/buffers through CLI-backed workflow.
+- Emitting JSON-equivalent match structures (`model_dump`).
+- Supporting practical local use inside `devenv.sh` personal environments.
+
+### Out of Scope
+
+- Graph building, traversal, pattern matching, or graph metrics.
+- Non-query static analysis features not directly tied to query execution (for example: complexity scoring, security linting rule packs, dependency graphing, architectural smell detection, or broad code-quality auditing).
+- Heavy orchestration frameworks.
+
+## Design Tenets
+
+1. **Typed at every boundary**
+   - Input, intermediate, and output data structures should be modeled.
+
+2. **Simple over comprehensive**
+   - Prefer obvious behavior and small APIs over feature sprawl.
+
+3. **CLI-centric integration**
+   - The Tree-sitter CLI integration should remain transparent and debuggable.
+
+4. **Neovim semantics as reference**
+   - Terminology and conceptual model should align with Neovim Tree-sitter usage.
+
+5. **Personal-dev-environment pragmatism**
+   - Optimize for local workflow reliability over enterprise-level extensibility.
+
+## Proposed High-Level API Surface
+
+> Names are conceptual and can evolve.
+
+- `QuerySpec` — language, query text, capture expectations, options.
+- `QueryTarget` — file path or in-memory content target.
+- `QueryRunner` — executes a query spec against a target.
+- `MatchResult` — normalized top-level result object.
+- `MatchItem` / `CaptureItem` — strongly typed result units.
+
+## Execution Model (Conceptual)
+
+1. User creates `QuerySpec` Pydantic model.
+2. User points runner at a file/string target.
+3. Runner invokes Tree-sitter CLI workflow.
+4. Raw output is parsed/normalized into Pydantic result models.
+5. User consumes:
+   - typed Python attributes,
+   - JSON-equivalent payload via `model_dump()`.
+
+## Non-Goals for Initial Iteration
+
+- Cross-language plugin ecosystem.
+- Distributed or remote execution.
+- Large-scale indexing/storage subsystems.
+- Advanced editor-integration frameworks.
+
+## Success Criteria
+
+A successful first release of this concept should make the following easy:
+
+1. Define a query in a typed model in <10 lines.
+2. Run it against a file in one call.
+3. Get stable, typed capture/match objects.
+4. Serialize directly to JSON-equivalent structures for automation scripts.
+
+## Migration Implications
+
+All graph-related documentation and APIs should be considered deprecated for this concept and removed or ignored in future iterations.
+
+## Summary
+
+Pydantree is becoming a **focused Python + Pydantic interface for Neovim Tree-sitter query workflows**, implemented as a **simple wrapper around Tree-sitter CLI behavior**, with **typed JSON-equivalent outputs** as the primary deliverable.

--- a/README.md
+++ b/README.md
@@ -1,407 +1,66 @@
 # Pydantree
 
-**Typed Tree-sitter wrapper with graph operations for Python AST analysis and transformation.**
+**A user-facing, Pythonic wrapper for Neovim Tree-sitter queries using Pydantic models.**
 
-Pydantree combines Tree-sitter's incremental parsing with Pydantic's type safety, providing a powerful toolkit for static analysis, code transformation, and AST pattern matching. 
+Pydantree is being refocused into a small, practical library for personal development environments (`devenv.sh`) where you want to:
 
-**V2:** Hopefully it'll be less out of hand this time?
+- define Tree-sitter query shapes as typed Pydantic models,
+- run those queries through the Tree-sitter CLI workflow,
+- and receive clean JSON-like, model-backed match data in Python.
 
-## Features
+This project is intentionally narrowing scope. It is **not** a graph-analysis toolkit.
 
-- 🔒 **Type-safe AST nodes** with Pydantic validation
-- ⚡ **Incremental parsing** for efficient code editing
-- 🔍 **Lazy collections** with Django-inspired query API
-- 📊 **Graph analysis** using rustworkx algorithms
-- 🎯 **Pattern matching** with VF2 isomorphism detection
-- 🔄 **Code transformation** framework
-- 🛠️ **CLI tools** for analysis and generation
+## Project Direction (New Scope)
 
-## Installation
+Pydantree now targets one core job:
 
-```bash
-# Basic installation
-pip install pydantree
+1. Represent query and match structures with Pydantic.
+2. Provide a Python-first API that maps closely to Neovim Tree-sitter query concepts.
+3. Execute query flows in a simple wrapper around Tree-sitter CLI usage.
+4. Emit structured JSON-equivalent match results for downstream automation.
 
-# With graph operations
-pip install pydantree[graph]
+For the detailed concept and architecture goals, see [CONCEPT.md](CONCEPT.md).
 
-# With CLI tools
-pip install pydantree[cli]
+## Core Principles
 
-# Development installation
-pip install pydantree[dev]
-```
+- **User-facing first**: the API should feel natural from Python, not like a thin C binding.
+- **Typed interfaces**: Pydantic models should be the primary data boundary.
+- **Simple operational model**: prioritize direct CLI-backed workflows over heavy abstraction.
+- **Neovim query alignment**: naming and behavior should mirror Tree-sitter query semantics used in Neovim.
+- **No graph layer**: graph-specific APIs and concepts are out of scope.
 
-## Quick Start
-
-### Basic Parsing
+## Intended Usage (Conceptual)
 
 ```python
-from pydantree import parse_python, find_functions, find_classes
+from pydantree import QuerySpec, QueryRunner
 
-code = '''
-def greet(name: str) -> str:
-    return f"Hello, {name}!"
-
-class Person:
-    def __init__(self, name: str):
-        self.name = name
-'''
-
-# Parse into typed AST
-module = parse_python(code)
-print(f"Parsed {len(module.node.children)} top-level nodes")
-
-# Find specific constructs
-functions = find_functions(code)
-classes = find_classes(code)
-
-print(f"Functions: {[f.name() for f in functions]}")
-print(f"Classes: {[c.name() for c in classes]}")
-```
-
-### High-Level Views
-
-```python
-from pydantree.views import PyModule
-
-module = PyModule.parse(code)
-
-# Chainable queries
-async_functions = (module.functions()
-                  .where(lambda f: f.is_async())
-                  .named("process_data"))
-
-# Method analysis
-for cls in module.classes():
-    methods = cls.methods()
-    print(f"{cls.name()}: {len(methods)} methods")
-    if cls.has_init():
-        print(f"  Has __init__ method")
-```
-
-### NodeGroup Collections
-
-```python
-from pydantree import NodeGroup
-
-# Create from AST tree
-nodegroup = NodeGroup.from_tree(module.node)
-
-# Lazy filtering and set operations
-identifiers = nodegroup.filter_type("identifier")
-functions = nodegroup.filter_type("function_definition")
-print_calls = nodegroup.filter_text("print", exact=False)
-
-# Combine with set algebra
-all_defs = functions.union(nodegroup.filter_type("class_definition"))
-print(f"Total definitions: {len(all_defs)}")
-
-# Group by type
-grouped = nodegroup.groupby(lambda n: n.type_name)
-for type_name, group in grouped.items():
-    if len(group) > 1:
-        print(f"{type_name}: {len(group)}")
-```
-
-### Code Transformation
-
-```python
-from pydantree.views import PyTransformer
-
-class PrintToLogger(PyTransformer):
-    def visit_expression_statement(self, node):
-        text = node.text.strip()
-        if text.startswith("print("):
-            return text.replace("print(", "logger.info(", 1)
-
-# Apply transformation
-transformer = PrintToLogger(module)
-transformed_code = transformer.visit()
-```
-
-### Graph Analysis
-
-```python
-from pydantree.graph import GraphBuilder, GraphAnalyzer
-
-# Build graph from AST
-builder = GraphBuilder(nodegroup)
-graph = builder.to_graph(directed=True, include_siblings=False)
-
-# Analyze structure
-analyzer = GraphAnalyzer(graph)
-metrics = analyzer.graph_metrics()
-components = analyzer.connected_components()
-
-print(f"Nodes: {metrics['num_nodes']}, Edges: {metrics['num_edges']}")
-print(f"Components: {len(components)}")
-```
-
-## Core Concepts
-
-### TSNode - Typed AST Nodes
-
-All AST nodes inherit from `TSNode`, providing immutable, validated representations:
-
-```python
-from pydantree.core import TSNode
-
-# Generated from node-types.json
-class FunctionDefinitionNode(TSNode):
-    __match_args__ = ('type_name', 'body', 'name', 'parameters')
-    
-    def name(self) -> str:
-        return self.child_by_field_name("name").text
-```
-
-### ParsedDocument - Incremental Parsing
-
-Maintains text and AST synchronization for efficient editing:
-
-```python
-from pydantree import ParsedDocument, Parser
-
-doc = ParsedDocument(text=code, parser=parser)
-
-# Apply incremental edit
-doc.edit(
-    start_byte=10,
-    old_end_byte=20,
-    new_end_byte=25,
-    new_text="replacement"
+spec = QuerySpec(
+    language="python",
+    query="""
+    (function_definition
+      name: (identifier) @function.name) @function.def
+    """,
+    captures=["function.def", "function.name"],
 )
-# AST automatically re-parsed with Tree-sitter's incremental algorithm
+
+runner = QueryRunner()
+result = runner.match_file("example.py", spec)
+
+# JSON-equivalent typed output
+print(result.model_dump())
 ```
 
-### NodeGroup - Lazy Collections
+## What is Explicitly Out of Scope
 
-Set-theoretic operations with lazy evaluation:
+- AST graph construction
+- Graph algorithms or isomorphism matching
+- Graph visualization
+- Multi-purpose static analysis platform ambitions (e.g., complexity analyzers, security scanners, or architecture-level auditing unrelated to query matches)
 
-```python
-# Lazy filtering - no computation until iteration
-filtered = nodegroup.filter_type("function_definition")
-methods = filtered.where(lambda n: "def " in n.text)
+## Development Notes
 
-# Set operations
-union_result = set1.union(set2)
-intersection = set1.intersection(set2)
-difference = set1.difference(set2)
-
-# Materialization
-concrete_list = list(filtered)  # Forces evaluation
-```
-
-## API Reference
-
-### Core Classes
-
-- **`TSNode`** - Base AST node with validation and navigation
-- **`Parser`** - Wrapper around tree-sitter with typed output
-- **`ParsedDocument`** - Incremental parsing with text sync
-- **`NodeGroup`** - Lazy collections with set operations
-
-### Views Layer
-
-- **`PyModule`** - High-level module wrapper
-- **`PyFunction`** - Function definition with semantic methods
-- **`PyClass`** - Class definition with method analysis
-- **`QuerySet`** - Django-inspired chainable queries
-- **`PyTransformer`** - Visitor pattern for code transformation
-
-### Graph Operations
-
-- **`GraphBuilder`** - Convert NodeGroup to rustworkx graphs
-- **`PatternMatcher`** - VF2 isomorphism for pattern detection
-- **`GraphAnalyzer`** - Centrality, paths, and connectivity analysis
-
-## Command Line Interface
-
-### Generate Node Classes
-
-```bash
-# Generate typed classes from Tree-sitter grammar
-pydantree generate node-types.json --out python_nodes.py
-```
-
-### AST Analysis
-
-```bash
-# Display AST structure
-pydantree ast example.py --format tree --depth 3
-
-# JSON output for programmatic use
-pydantree ast example.py --format json > ast.json
-```
-
-### Query Operations
-
-```bash
-# Find specific node types
-pydantree query example.py --type function_definition --count
-
-# Text-based search
-pydantree query example.py --text "async def" 
-
-# Complex filtering
-pydantree query example.py --type class_definition --text "__init__"
-```
-
-### Code Transformation
-
-```bash
-# Apply built-in transformations
-pydantree transform example.py --transform print_to_logger --out modified.py
-
-# View transformation without saving
-pydantree transform example.py --transform print_to_logger
-```
-
-### Graph Analysis
-
-```bash
-# Graph metrics and statistics
-pydantree graph example.py --format stats
-
-# Include sibling relationships
-pydantree graph example.py --siblings --format stats
-```
-
-## Advanced Usage
-
-### Pattern Matching
-
-```python
-from pydantree.graph import PatternMatcher, build_pattern_graph
-
-# Define pattern AST
-pattern_code = "def example(): pass"
-pattern_module = parse_python(pattern_code)
-pattern_graph = build_pattern_graph([pattern_module.node])
-
-# Find matches in target
-target_graph = build_tree_graph(target_nodegroup)
-matcher = PatternMatcher(pattern_graph)
-matches = matcher.find_matches(target_graph)
-```
-
-### Custom Node Generation
-
-```bash
-# Generate from your own Tree-sitter grammar
-pydantree generate my-grammar/node-types.json \
-    --out custom_nodes.py \
-    --base-class CustomTSNode \
-    --token-suffix Token
-```
-
-### Bulk Operations
-
-```python
-# Bulk transformation with NodeGroup
-def transform_function_names(nodegroup):
-    functions = nodegroup.filter_type("function_definition")
-    return functions.map(lambda f: f.replace_child(
-        f.child_by_field_name("name"),
-        create_identifier(f"new_{f.name()}")
-    ))
-
-# Apply to entire codebase
-transformed = transform_function_names(codebase_nodegroup)
-```
-
-## Development
-
-### Project Structure
-
-```
-pydantree/
-├── src/pydantree/
-│   ├── core.py           # Base TSNode and TSPoint models
-│   ├── parser.py         # Parser wrapper
-│   ├── incremental.py    # ParsedDocument for incremental parsing
-│   ├── codegen.py        # Node class generation
-│   ├── nodegroup.py      # Lazy collections
-│   ├── graph.py          # Graph operations (requires rustworkx)
-│   ├── views.py          # High-level Python views
-│   └── cli.py            # Command-line interface
-├── src/data/
-│   ├── node-types.json   # Tree-sitter Python grammar
-│   └── python_nodes.py   # Generated node classes
-└── src/examples/         # Usage examples
-```
-
-### Setup Development Environment
-
-```bash
-# Clone repository
-git clone https://github.com/yourusername/pydantree.git
-cd pydantree
-
-# Install with uv (recommended)
-uv venv
-source .venv/bin/activate  # or .venv\Scripts\activate on Windows
-uv sync --dev
-
-# Or with pip
-pip install -e ".[dev,graph,cli]"
-
-# Run tests
-pytest tests/
-
-# Type checking
-mypy src/pydantree/
-
-# Code formatting
-ruff format src/
-ruff check src/ --fix
-```
-
-### Dependencies
-
-**Core:**
-- `pydantic>=2.11` - Type validation and serialization
-- `tree-sitter>=0.23` - Incremental parsing
-- `tree-sitter-python>=0.23.6` - Python grammar
-
-**Optional:**
-- `rustworkx>=0.14.0` - Graph algorithms (for graph operations)
-- `typer>=0.12.0` - CLI framework
-- `rich>=13.0.0` - Terminal formatting
-
-## Performance Notes
-
-- **Lazy evaluation**: NodeGroup operations are lazy until materialized
-- **Incremental parsing**: Tree-sitter only re-parses changed regions
-- **Memory efficiency**: Immutable nodes with structural sharing
-- **Graph caching**: Graph conversions can be cached for repeated analysis
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make changes with tests
-4. Run the test suite (`pytest`)
-5. Submit a pull request
-
-### Code Style
-
-- Use `ruff` for formatting and linting
-- Type hints required for public APIs
-- Docstrings for all public functions
-- Keep line length under 80 characters
-- Follow Pydantic model conventions
+This repository is currently in a concept-first transition. As implementation evolves, the README will track concrete APIs and installation details aligned to the narrowed scope.
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) file for details.
-
-## Related Projects
-
-- [tree-sitter](https://tree-sitter.github.io/) - Incremental parsing library
-- [pydantic](https://pydantic.dev/) - Data validation using Python type hints
-- [rustworkx](https://rustworkx.readthedocs.io/) - High-performance graph algorithms
-- [libcst](https://libcst.readthedocs.io/) - Concrete syntax tree library for Python
-
-
-```
+MIT License - see [LICENSE](LICENSE).


### PR DESCRIPTION
### Motivation
- Make the ambiguous line about “non-query static analysis features not directly tied to query execution” explicit by giving concrete examples so readers understand what Pydantree intentionally excludes.

### Description
- Updated `CONCEPT.md` and `README.md` to replace the vague out-of-scope phrase with explicit examples (e.g., complexity scoring, security lint rule packs, dependency/architecture graphing, and broad code-quality auditing) and aligned both files to the same boundary language.

### Testing
- Ran `git diff -- CONCEPT.md README.md` and `git rev-parse --short HEAD` to verify the changes and recorded commit (`Clarify out-of-scope static-analysis wording`), and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d53f611d08333b16e8c5b428708f0)