### PR TITLE
Document shell-first `just` workflow contract in docs

### DIFF
--- a/CONCEPT.md
+++ b/CONCEPT.md
@@ -43,6 +43,39 @@ Pydantree provides:
 - Generic metric/security/static-analysis suites.
 - Large framework-level orchestration.
 
+
+## Shell-first command contract
+
+The user-facing workflow is defined by a shell-first `just` contract. Commands accept grammar/query-pack names and resolve all paths internally from repository root.
+
+### Contract
+
+```bash
+just workshop-init
+just scaffold <language> <query-pack>
+just ingest <language> <query-pack>
+just generate-models <language> <query-pack>
+just validate <language> <query-pack>
+just run-query <language> <query-pack> <source>
+just doctor <language> <query-pack>
+```
+
+### Interface guarantees
+
+1. `just workshop-init` prepares workshop-local state and indexes known grammars/query packs.
+2. `just scaffold <language> <query-pack>` creates deterministic starter assets for a named grammar/query pack pair.
+3. `just ingest <language> <query-pack>` loads and normalizes query artifacts into the internal representation.
+4. `just generate-models <language> <query-pack>` emits deterministic Pydantic models from normalized query data.
+5. `just validate <language> <query-pack>` checks schema integrity and runtime readiness for that pair.
+6. `just run-query <language> <query-pack> <source>` executes a named query pack against a named source input and returns typed output.
+7. `just doctor <language> <query-pack>` runs diagnostics for environment, assets, and configuration for that pair.
+
+### Resolution policy
+
+- Public inputs are semantic names, not paths.
+- Implementations must resolve canonical filesystem locations from repository root.
+- Raw path arguments for grammar/query-pack assets are intentionally out of contract.
+
 ## Design tenets
 
 1. Typed at every boundary.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,36 @@ Pydantree is a focused library for turning Tree-sitter query artifacts (for exam
 - Generate deterministic Pydantic model code.
 - Execute queries and return typed, JSON-equivalent results.
 
+## Shell-first command contract
+
+Pydantree's workshop workflow is shell-first. The `just` interface is the canonical public contract, and command arguments use **grammar names** and **query-pack names** (never raw filesystem paths).
+
+### Contract
+
+```bash
+just workshop-init
+just scaffold <language> <query-pack>
+just ingest <language> <query-pack>
+just generate-models <language> <query-pack>
+just validate <language> <query-pack>
+just run-query <language> <query-pack> <source>
+just doctor <language> <query-pack>
+```
+
+### Argument semantics
+
+- `<language>`: a grammar identifier, such as `python`, `typescript`, or `go`.
+- `<query-pack>`: a named query collection for that grammar, such as `highlights`, `tags`, or another pack name exposed by the repository.
+- `<source>`: source input selector for query execution (for example, a fixture key, inline content key, or configured source alias).
+
+### Path-resolution rule
+
+All filesystem paths are resolved **internally from repository root**.
+
+- Users provide only stable names (`<language>`, `<query-pack>`, `<source>`).
+- Command implementations map those names to canonical repository locations.
+- No command in the public contract accepts raw local paths to grammar/query assets.
+
 ## Scope
 
 In scope:


### PR DESCRIPTION
### Motivation

- Provide a canonical, shell-first public contract for the repository so workshop interactions are consistent and discoverable. 
- Force semantic inputs (`<language>`, `<query-pack>`, `<source>`) instead of raw filesystem paths to improve stability and make implementations resolve assets from the repository root.

### Description

- Add a `Shell-first command contract` section to `README.md` that lists the canonical `just` commands and describes argument semantics and path-resolution rules. 
- Mirror the contract in `CONCEPT.md` and expand with explicit per-command interface guarantees for `workshop-init`, `scaffold`, `ingest`, `generate-models`, `validate`, `run-query`, and `doctor`.
- Document the resolution policy that public inputs are semantic names and implementations must map those names to canonical repository locations (no raw-path arguments in the public interface).

### Testing

- Run `pytest -q`, which reported no tests were collected / no tests ran in the repository state.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfe2a416483338f66d1dd9e040845)