### PR TITLE
Add CUE schemas and validation-gated generation CLI wrappers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dev = [
   "black>=24.0.0",
 ]
 
+[project.scripts]
+pydantree = "pydantree.cli:app"
+
 [project.urls]
 Homepage = "https://github.com/pydantree/pydantree"
 Repository = "https://github.com/pydantree/pydantree"

--- a/src/pydantree/__init__.py
+++ b/src/pydantree/__init__.py
@@ -1,0 +1,8 @@
+"""Pydantree package."""
+
+__all__ = ["__version__"]
+
+try:
+    from pydantree._version import __version__
+except Exception:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/src/pydantree/cli.py
+++ b/src/pydantree/cli.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from pathlib import Path
+
+import typer
+
+from pydantree.cue_validation import CueUnavailableError, run_cue_validation
+
+app = typer.Typer(help="Pydantree generation wrappers with CUE validation gates.")
+
+
+def _schema_path(schema_name: str, schema_dir: Path | None = None) -> Path:
+    if schema_dir is not None:
+        return schema_dir / schema_name
+    return Path(__file__).resolve().parent / "cue" / schema_name
+
+
+def _emit_validation_result(result_name: str, ok: bool, details: list[str]) -> None:
+    if ok:
+        typer.echo(f"{result_name}: ok")
+        return
+    typer.echo(f"{result_name}: failed")
+    for detail in details:
+        typer.echo(f"  - {detail}")
+
+
+@app.command("validate-ir")
+def validate_ir(
+    ir_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    schema_dir: Path | None = typer.Option(None, help="Optional directory containing CUE schemas."),
+) -> None:
+    schema_file = _schema_path("ir_schema.cue", schema_dir)
+    try:
+        result = run_cue_validation(ir_file, schema_file)
+    except CueUnavailableError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+
+    _emit_validation_result("IR validation", result.ok, result.details)
+    if not result.ok:
+        raise typer.Exit(code=1)
+
+
+@app.command("validate-manifest")
+def validate_manifest(
+    manifest_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    schema_dir: Path | None = typer.Option(None, help="Optional directory containing CUE schemas."),
+) -> None:
+    schema_file = _schema_path("manifest_schema.cue", schema_dir)
+    try:
+        result = run_cue_validation(manifest_file, schema_file)
+    except CueUnavailableError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+
+    _emit_validation_result("Manifest validation", result.ok, result.details)
+    if not result.ok:
+        raise typer.Exit(code=1)
+
+
+@app.command("generate")
+def generate(
+    ir_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    manifest_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    generator_cmd: str = typer.Option(..., help="Shell command used for generation."),
+    schema_dir: Path | None = typer.Option(None, help="Optional directory containing CUE schemas."),
+) -> None:
+    ir_schema = _schema_path("ir_schema.cue", schema_dir)
+    manifest_schema = _schema_path("manifest_schema.cue", schema_dir)
+
+    try:
+        pre_result = run_cue_validation(ir_file, ir_schema)
+    except CueUnavailableError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+
+    _emit_validation_result("Pre-generation IR validation", pre_result.ok, pre_result.details)
+    if not pre_result.ok:
+        raise typer.Exit(code=1)
+
+    command_parts = shlex.split(generator_cmd)
+    generation = subprocess.run(command_parts, check=False, text=True, capture_output=True)
+    if generation.stdout:
+        typer.echo(generation.stdout.rstrip())
+    if generation.returncode != 0:
+        if generation.stderr:
+            typer.echo(generation.stderr.rstrip())
+        raise typer.Exit(code=generation.returncode)
+
+    post_result = run_cue_validation(manifest_file, manifest_schema)
+    _emit_validation_result("Post-generation manifest validation", post_result.ok, post_result.details)
+    if not post_result.ok:
+        raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/pydantree/cue/ir_schema.cue
+++ b/src/pydantree/cue/ir_schema.cue
@@ -1,0 +1,30 @@
+package pydantree
+
+#Capture: {
+    name: string
+    node?: string
+    source?: {
+        file: string
+        line?: >=1 & int
+        column?: >=1 & int
+    }
+}
+
+#Pattern: {
+    id?: string
+    pattern: string
+    captures: [...#Capture]
+}
+
+#QueryMetadata: {
+    language: string
+    query_type: string
+    source_scm: string
+    generated_by?: string
+}
+
+#IR: {
+    version: "v1"
+    patterns: [...#Pattern]
+    query_metadata: #QueryMetadata
+}

--- a/src/pydantree/cue/manifest_schema.cue
+++ b/src/pydantree/cue/manifest_schema.cue
@@ -1,0 +1,8 @@
+package pydantree
+
+#Manifest: {
+    input_hashes: [string]: string
+    toolchain_versions: [string]: string
+    output_file_hashes: [string]: string
+    generated_at?: string
+}

--- a/src/pydantree/cue_validation.py
+++ b/src/pydantree/cue_validation.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    ok: bool
+    summary: str
+    details: list[str]
+
+
+class CueUnavailableError(RuntimeError):
+    """Raised when the CUE CLI is not available."""
+
+
+_CAPTURE_PATTERNS = [
+    re.compile(r"captures\[(\d+)\]"),
+    re.compile(r"captures\.(\d+)"),
+]
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _capture_context(ir_data: Any, capture_idx: int) -> tuple[str | None, str | None]:
+    if not isinstance(ir_data, dict):
+        return (None, None)
+
+    metadata = ir_data.get("query_metadata") or ir_data.get("metadata") or {}
+    source_scm = metadata.get("source_scm") if isinstance(metadata, dict) else None
+
+    patterns = ir_data.get("patterns") or ir_data.get("pattern") or []
+    if isinstance(patterns, dict):
+        patterns = [patterns]
+
+    captures: list[dict[str, Any]] = []
+    for pattern in patterns:
+        if not isinstance(pattern, dict):
+            continue
+        items = pattern.get("captures", [])
+        if isinstance(items, list):
+            captures.extend(item for item in items if isinstance(item, dict))
+
+    if capture_idx >= len(captures):
+        return (source_scm, None)
+
+    capture = captures[capture_idx]
+    capture_name = capture.get("name")
+    src = capture.get("source")
+    if isinstance(src, dict):
+        source_scm = src.get("file") or source_scm
+
+    return (source_scm, capture_name if isinstance(capture_name, str) else None)
+
+
+def _map_context(line: str, ir_data: Any) -> str:
+    capture_idx: int | None = None
+    for pattern in _CAPTURE_PATTERNS:
+        match = pattern.search(line)
+        if match:
+            capture_idx = int(match.group(1))
+            break
+
+    if capture_idx is None:
+        return line.strip()
+
+    source_scm, capture_name = _capture_context(ir_data, capture_idx)
+    context_parts = []
+    if source_scm:
+        context_parts.append(f"scm={source_scm}")
+    if capture_name:
+        context_parts.append(f"capture={capture_name}")
+
+    if not context_parts:
+        return line.strip()
+
+    return f"{line.strip()} [{' '.join(context_parts)}]"
+
+
+def run_cue_validation(data_file: Path, schema_file: Path) -> ValidationResult:
+    if shutil.which("cue") is None:
+        raise CueUnavailableError("CUE CLI not found in PATH.")
+
+    completed = subprocess.run(
+        ["cue", "vet", str(data_file), str(schema_file)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if completed.returncode == 0:
+        return ValidationResult(ok=True, summary="validation passed", details=[])
+
+    raw_lines = [line for line in completed.stderr.splitlines() if line.strip()]
+    if not raw_lines:
+        raw_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+
+    ir_data = _load_json(data_file)
+    mapped = [_map_context(line, ir_data) for line in raw_lines[:5]]
+
+    return ValidationResult(ok=False, summary="validation failed", details=mapped)

--- a/tests/test_cue_validation.py
+++ b/tests/test_cue_validation.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantree.cue_validation import _map_context
+
+
+def test_map_context_with_capture_information(tmp_path: Path) -> None:
+    ir_file = tmp_path / "ir.json"
+    ir_file.write_text(
+        '{"version":"v1","patterns":[{"pattern":"(function)","captures":[{"name":"function.name","source":{"file":"queries/highlights.scm"}}]}],"query_metadata":{"language":"python","query_type":"highlights","source_scm":"queries/highlights.scm"}}',
+        encoding="utf-8",
+    )
+
+    ir_data = {
+        "version": "v1",
+        "patterns": [
+            {
+                "pattern": "(function)",
+                "captures": [
+                    {"name": "function.name", "source": {"file": "queries/highlights.scm"}}
+                ],
+            }
+        ],
+        "query_metadata": {
+            "language": "python",
+            "query_type": "highlights",
+            "source_scm": "queries/highlights.scm",
+        },
+    }
+
+    line = "ir.json: captures[0].name: invalid value 123 (out of bound string type)"
+    mapped = _map_context(line, ir_data)
+
+    assert "capture=function.name" in mapped
+    assert "scm=queries/highlights.scm" in mapped


### PR DESCRIPTION
### Motivation
- Provide typed CUE schemas for the internal IR and generation manifest to enable machine-checkable validation of query artifacts and generation provenance.
- Enforce validation gates around generation so invalid IR never proceeds to generation and generated manifests are checked immediately after emit.

### Description
- Add `ir_schema.cue` defining `#Capture`, `#Pattern`, `#QueryMetadata`, and top-level `#IR` with `version`, `patterns`, and `query_metadata` fields under `src/pydantree/cue/`.
- Add `manifest_schema.cue` defining `#Manifest` with `input_hashes`, `toolchain_versions`, and `output_file_hashes` under `src/pydantree/cue/`.
- Implement CUE validation helper `run_cue_validation` and helpers that map CUE `captures[...]` errors to `scm=...` and `capture=...` context where available in `src/pydantree/cue_validation.py`.
- Add a Typer-based CLI `pydantree` with commands `validate-ir`, `validate-manifest`, and `generate` that run CUE validation pre- and post-generation and emit concise, enriched error lines in `src/pydantree/cli.py`.
- Expose the CLI via `pyproject.toml` `[project.scripts]` and add a small unit test for the capture/source context mapping in `tests/test_cue_validation.py`.

### Testing
- Running tests with `PYTHONPATH=src python -m pytest -q` executed the new unit test and passed (`1 passed`).
- Compiled package sources with `PYTHONPATH=src python -m compileall -q src tests` and it completed successfully.
- Note: a plain `python -m pytest -q` run failed in the earlier environment due to `src/` not being on `PYTHONPATH`, so CI should run tests with the package import path set (as shown).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dfec1cb8c8333af97c3c63635a4c3)