### PR TITLE
Add explicit typed codegen pipeline stages and CLI commands

### DIFF
--- a/src/pydantree/cli.py
+++ b/src/pydantree/cli.py
@@ -7,10 +7,84 @@ from pathlib import Path
 
 import typer
 
+from pydantree.codegen.common import CodegenDiagnosticError, read_model, write_model
+from pydantree.codegen.emit import EmitOutput, emit_models
+from pydantree.codegen.ingest import IngestOutput, ingest_scm
+from pydantree.codegen.manifest import build_manifest
+from pydantree.codegen.normalize import NormalizeOutput, normalize_ingested
 from pydantree.doctor import format_human_summary, run_doctor
 from pydantree.cue_validation import CueUnavailableError, run_cue_validation
 
 app = typer.Typer(help="Pydantree generation wrappers with CUE validation gates.")
+
+
+@app.command("codegen-ingest")
+def codegen_ingest(
+    root_dir: Path = typer.Argument(..., exists=True, file_okay=False, readable=True),
+    out: Path = typer.Option(Path("build/ingest.json"), help="Output JSON artifact path."),
+    pattern: str = typer.Option("*.scm", help="Glob used for query discovery."),
+) -> None:
+    """Discover .scm files and collect provenance metadata."""
+    try:
+        payload = ingest_scm(root_dir=root_dir, pattern=pattern)
+    except CodegenDiagnosticError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+    write_model(out, payload)
+    typer.echo(f"Wrote ingest artifact: {out}")
+
+
+@app.command("codegen-normalize")
+def codegen_normalize(
+    input_path: Path = typer.Option(Path("build/ingest.json"), "--input", help="Ingest artifact path."),
+    out: Path = typer.Option(Path("build/normalize.json"), help="Output JSON artifact path."),
+) -> None:
+    """Normalize ingested queries into stable pattern IDs."""
+    try:
+        ingest = IngestOutput.model_validate(read_model(input_path, IngestOutput))
+        normalized = normalize_ingested(ingest)
+    except CodegenDiagnosticError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+    write_model(out, normalized)
+    typer.echo(f"Wrote normalize artifact: {out}")
+
+
+@app.command("codegen-emit")
+def codegen_emit(
+    input_path: Path = typer.Option(Path("build/normalize.json"), "--input", help="Normalize artifact path."),
+    output_dir: Path = typer.Option(Path("build/generated"), help="Directory for generated modules."),
+    out: Path = typer.Option(Path("build/emit.json"), help="Output JSON artifact path."),
+) -> None:
+    """Generate deterministic Pydantic modules from normalized queries."""
+    try:
+        normalize = NormalizeOutput.model_validate(read_model(input_path, NormalizeOutput))
+        emitted = emit_models(normalize, output_dir=output_dir)
+    except CodegenDiagnosticError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+    write_model(out, emitted)
+    typer.echo(f"Wrote emit artifact: {out}")
+
+
+@app.command("codegen-manifest")
+def codegen_manifest(
+    ingest_path: Path = typer.Option(Path("build/ingest.json"), "--ingest", help="Ingest artifact path."),
+    normalize_path: Path = typer.Option(Path("build/normalize.json"), "--normalize", help="Normalize artifact path."),
+    emit_path: Path = typer.Option(Path("build/emit.json"), "--emit", help="Emit artifact path."),
+    out: Path = typer.Option(Path("build/manifest.json"), help="Output manifest artifact path."),
+) -> None:
+    """Build reproducibility metadata for the complete codegen pipeline."""
+    try:
+        ingest = IngestOutput.model_validate(read_model(ingest_path, IngestOutput))
+        normalize = NormalizeOutput.model_validate(read_model(normalize_path, NormalizeOutput))
+        emit = EmitOutput.model_validate(read_model(emit_path, EmitOutput))
+        manifest = build_manifest(ingest=ingest, normalize=normalize, emit=emit)
+    except CodegenDiagnosticError as exc:
+        typer.echo(str(exc))
+        raise typer.Exit(code=2) from exc
+    write_model(out, manifest)
+    typer.echo(f"Wrote manifest artifact: {out}")
 
 
 @app.command("doctor")

--- a/src/pydantree/codegen/manifest.py
+++ b/src/pydantree/codegen/manifest.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from hashlib import sha256
 
 from pydantic import BaseModel, ConfigDict
 
+from pydantree.codegen.common import CodegenDiagnosticError
 from pydantree.codegen.emit import EmitOutput
 from pydantree.codegen.ingest import IngestOutput
 from pydantree.codegen.normalize import NormalizeOutput
@@ -23,16 +25,30 @@ class ReproducibilityManifest(BaseModel):
 
 
 def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitOutput) -> ReproducibilityManifest:
+    if len(ingest.queries) != len(normalize.queries):
+        raise CodegenDiagnosticError(
+            "manifest",
+            "Ingest and normalize query counts do not match.",
+            hint="Ensure normalize was produced from the same ingest artifact.",
+        )
+    if len(normalize.queries) != len(emit.modules):
+        raise CodegenDiagnosticError(
+            "manifest",
+            "Normalize and emit counts do not match.",
+            hint="Ensure emit was produced from the same normalize artifact.",
+        )
+
     return ReproducibilityManifest(
         generated_at=datetime.now(UTC),
-        pipeline_version="1",
-        ingest_fingerprint=_fingerprint(ingest.model_dump_json()),
-        normalize_fingerprint=_fingerprint(normalize.model_dump_json()),
-        emit_fingerprint=_fingerprint(emit.model_dump_json()),
+        pipeline_version="2",
+        ingest_fingerprint=_fingerprint(ingest.model_dump(mode="json")),
+        normalize_fingerprint=_fingerprint(normalize.model_dump(mode="json")),
+        emit_fingerprint=_fingerprint(emit.model_dump(mode="json")),
         query_count=len(normalize.queries),
         module_count=len(emit.modules),
     )
 
 
-def _fingerprint(payload: str) -> str:
-    return sha256(payload.encode("utf-8")).hexdigest()
+def _fingerprint(payload: object) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return sha256(canonical.encode("utf-8")).hexdigest()

--- a/src/pydantree/codegen/normalize.py
+++ b/src/pydantree/codegen/normalize.py
@@ -21,6 +21,7 @@ class NormalizedCapture(BaseModel):
 class NormalizedPattern(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    ordinal: int
     pattern_id: str
     source: str
     captures: tuple[NormalizedCapture, ...]
@@ -48,21 +49,30 @@ def normalize_ingested(payload: IngestOutput) -> NormalizeOutput:
         )
 
     normalized_queries = []
-    ordered = sorted(payload.queries, key=lambda query: query.provenance.file_path)
-    for query in ordered:
-        patterns = _extract_patterns(query.source_text)
+    ordered_queries = sorted(payload.queries, key=lambda query: query.provenance.file_path)
+    for query in ordered_queries:
+        patterns = _extract_patterns(query.source_text, query.provenance.file_path)
         if not patterns:
             raise CodegenDiagnosticError(
                 "normalize",
                 f"Query file {query.provenance.file_path} did not contain any parseable patterns.",
                 hint="Ensure the file has non-comment, non-empty pattern lines.",
             )
+
+        dedupe_check = {pattern.pattern_id for pattern in patterns}
+        if len(dedupe_check) != len(patterns):
+            raise CodegenDiagnosticError(
+                "normalize",
+                f"Duplicate pattern IDs were generated for {query.provenance.file_path}",
+                hint="Check for repeated patterns or report this hash-collision bug.",
+            )
+
         normalized_queries.append(NormalizedQuery(provenance=query.provenance, patterns=tuple(patterns)))
 
     return NormalizeOutput(queries=tuple(normalized_queries))
 
 
-def _extract_patterns(source_text: str) -> list[NormalizedPattern]:
+def _extract_patterns(source_text: str, file_path: str) -> list[NormalizedPattern]:
     cleaned_lines = [line.strip() for line in source_text.splitlines() if line.strip() and not line.strip().startswith(";")]
     patterns: list[NormalizedPattern] = []
 
@@ -72,7 +82,15 @@ def _extract_patterns(source_text: str) -> list[NormalizedPattern]:
             NormalizedCapture(capture_id=f"cap_{sha1(name.encode('utf-8')).hexdigest()[:10]}", name=name)
             for name in capture_names
         ]
-        pattern_id = f"pat_{sha1(f'{ordinal}:{pattern_text}'.encode('utf-8')).hexdigest()[:10]}"
-        patterns.append(NormalizedPattern(pattern_id=pattern_id, source=pattern_text, captures=tuple(captures)))
+        pattern_hash_seed = f"{file_path}:{ordinal}:{pattern_text}"
+        pattern_id = f"pat_{sha1(pattern_hash_seed.encode('utf-8')).hexdigest()[:12]}"
+        patterns.append(
+            NormalizedPattern(
+                ordinal=ordinal,
+                pattern_id=pattern_id,
+                source=pattern_text,
+                captures=tuple(captures),
+            )
+        )
 
-    return sorted(patterns, key=lambda pattern: (pattern.pattern_id, pattern.source))
+    return patterns

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -22,9 +22,12 @@ def test_pipeline_roundtrip(tmp_path: Path) -> None:
     manifest = build_manifest(ingest, normalize, emit)
 
     assert len(ingest.queries) == 1
+    assert ingest.queries[0].provenance.source_bytes > 0
     assert len(normalize.queries[0].patterns) == 1
+    assert normalize.queries[0].patterns[0].ordinal == 1
     assert len(emit.modules) == 1
     assert manifest.query_count == 1
+    assert manifest.pipeline_version == "2"
     assert (tmp_path / "generated" / "python_highlights_models.py").exists()
 
 
@@ -34,3 +37,25 @@ def test_ingest_fails_without_scm(tmp_path: Path) -> None:
 
     with pytest.raises(CodegenDiagnosticError, match="No query files matching pattern"):
         ingest_scm(empty)
+
+
+def test_ingest_fails_on_empty_scm_file(tmp_path: Path) -> None:
+    query_dir = tmp_path / "queries"
+    query_dir.mkdir(parents=True)
+    (query_dir / "empty.scm").write_text("\n", encoding="utf-8")
+
+    with pytest.raises(CodegenDiagnosticError, match="Query file is empty"):
+        ingest_scm(query_dir)
+
+
+def test_manifest_fails_with_mismatched_emit_payload(tmp_path: Path) -> None:
+    query_dir = tmp_path / "queries" / "python"
+    query_dir.mkdir(parents=True)
+    (query_dir / "highlights.scm").write_text("(identifier) @id\n", encoding="utf-8")
+
+    ingest = ingest_scm(tmp_path / "queries")
+    normalize = normalize_ingested(ingest)
+    emit = emit_models(normalize, tmp_path / "generated")
+
+    with pytest.raises(CodegenDiagnosticError, match="Normalize and emit counts do not match"):
+        build_manifest(ingest, normalize, emit.model_copy(update={"modules": tuple()}))


### PR DESCRIPTION
### Motivation
- Provide an explicit, typed 4-stage codegen pipeline (`ingest` → `normalize` → `emit` → `manifest`) to enforce validation and reproducibility guarantees.
- Surface actionable diagnostics at stage boundaries so failures give clear hints for remediation.
- Ensure deterministic generation of Pydantic model modules and reproducible manifest fingerprints.
- Expose each stage as direct CLI commands and keep scripted `just` targets for automation.

### Description
- Introduced stronger ingest semantics in `src/pydantree/codegen/ingest.py` including `.scm` discovery filtering, empty-file failure, and richer provenance with `source_bytes` and `source_sha256` in `QueryProvenance`.
- Enhanced normalization in `src/pydantree/codegen/normalize.py` with stable query ordering, explicit per-pattern `ordinal`, deterministic `pattern_id` seeded by `file_path:ordinal:pattern_text`, and duplicate-ID diagnostics.
- Updated emit behavior in `src/pydantree/codegen/emit.py` to enforce deterministic ordering, detect module-name collisions, include `ordinal` in generated `Pattern` models, and return sorted `EmitOutput.modules`.
- Hardened manifest generation in `src/pydantree/codegen/manifest.py` by validating cross-stage counts and computing canonical JSON fingerprints (pipeline `pipeline_version` bumped to `"2"`).
- Exposed pipeline stages via the main Typer CLI in `src/pydantree/cli.py` as `codegen-ingest`, `codegen-normalize`, `codegen-emit`, and `codegen-manifest`, using typed read/write helpers and surfacing `CodegenDiagnosticError` as exit status 2.
- Added/updated tests in `tests/test_codegen_pipeline.py` to cover provenance bytes, pattern ordinals, empty-file failure, manifest mismatch diagnostics, and end-to-end roundtrip behavior.

### Testing
- Ran `pytest -q tests/test_codegen_pipeline.py`, which completed successfully with `4 passed`.
- Ran `python -m compileall -q src tests`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1302dedc8333a205be97cbf9875e)