### PR TITLE
Add CUE-validated generation wrapper, manifest schema integration, and improved CUE diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ PYTHONPATH=src python -m pydantree.cli validate-manifest build/manifest.json --s
 pytest tests/test_codegen_pipeline.py
 ```
 
+For a single wrapper command that runs CUE validation before/after generation:
+
+```bash
+PYTHONPATH=src python -m pydantree.codegen.cli generate \
+  workshop/queries/python/minimal_pack \
+  --output-dir src/pydantree/generated/python/minimal_pack \
+  --build-dir build \
+  --schema-dir src/pydantree/cue
+```
+
+Validation failures include concise context with mapped `.scm` file and capture name when available.
+
 ### 5) Run query against fixture source
 
 Use the workshop contract command with logical names (no raw query file paths):

--- a/src/pydantree/codegen/cli.py
+++ b/src/pydantree/codegen/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from pydantree.codegen.emit import EmitOutput, emit_models
 from pydantree.codegen.ingest import IngestOutput, ingest_scm
 from pydantree.codegen.manifest import build_manifest
 from pydantree.codegen.normalize import NormalizeOutput, normalize_ingested
+from pydantree.cue_validation import CueUnavailableError, ValidationResult, run_cue_validation
 
 
 def main() -> None:
@@ -50,7 +52,59 @@ def _build_parser() -> argparse.ArgumentParser:
     manifest.add_argument("--emit", type=Path, default=Path("build/emit.json"), dest="emit_path")
     manifest.add_argument("--out", type=Path, default=Path("build/manifest.json"))
 
+    generate = subparsers.add_parser(
+        "generate",
+        help="Run ingest/normalize/emit/manifest with CUE validation before and after generation",
+    )
+    generate.add_argument("root_dir", type=Path)
+    generate.add_argument("--pattern", default="*.scm")
+    generate.add_argument("--output-dir", type=Path, default=Path("build/generated"))
+    generate.add_argument("--build-dir", type=Path, default=Path("build"))
+    generate.add_argument("--schema-dir", type=Path, default=Path("src/pydantree/cue"))
+
     return parser
+
+
+def _schema_path(schema_dir: Path, name: str) -> Path:
+    return schema_dir / name
+
+
+def _emit_validation(result_name: str, result: ValidationResult) -> None:
+    if result.ok:
+        print(f"{result_name}: ok")
+        return
+    print(f"{result_name}: failed", file=sys.stderr)
+    for detail in result.details:
+        print(f"  - {detail}", file=sys.stderr)
+
+
+def _query_ir_payload(query: object) -> dict[str, object]:
+    from pydantree.codegen.normalize import NormalizedQuery
+
+    normalized = NormalizedQuery.model_validate(query)
+    return {
+        "version": "v1",
+        "patterns": [
+            {
+                "id": pattern.pattern_id,
+                "pattern": pattern.source,
+                "captures": [
+                    {
+                        "name": capture.name,
+                        "source": {"file": normalized.provenance.file_path},
+                    }
+                    for capture in pattern.captures
+                ],
+            }
+            for pattern in normalized.patterns
+        ],
+        "query_metadata": {
+            "language": normalized.provenance.language,
+            "query_type": normalized.provenance.query_type,
+            "source_scm": normalized.provenance.file_path,
+            "generated_by": "pydantree-codegen",
+        },
+    }
 
 
 def _dispatch(args: argparse.Namespace) -> None:
@@ -81,6 +135,52 @@ def _dispatch(args: argparse.Namespace) -> None:
         manifest = build_manifest(ingest=ingest, normalize=normalize, emit=emit)
         write_model(args.out, manifest)
         print(f"Wrote manifest artifact: {args.out}")
+        return
+
+    if args.command == "generate":
+        ingest = ingest_scm(root_dir=args.root_dir, pattern=args.pattern)
+        normalize = normalize_ingested(ingest)
+
+        build_dir: Path = args.build_dir
+        build_dir.mkdir(parents=True, exist_ok=True)
+        ir_schema = _schema_path(args.schema_dir, "ir_schema.cue")
+
+        for query in normalize.queries:
+            ir_file = build_dir / f"ir.{query.provenance.language}.{query.provenance.query_type}.json"
+            ir_file.write_text(json.dumps(_query_ir_payload(query), indent=2), encoding="utf-8")
+            try:
+                validation = run_cue_validation(ir_file, ir_schema)
+            except CueUnavailableError as exc:
+                raise CodegenDiagnosticError("generate", str(exc)) from exc
+            _emit_validation(f"Pre-generation IR validation ({query.provenance.file_path})", validation)
+            if not validation.ok:
+                raise CodegenDiagnosticError("generate", f"IR validation failed for {query.provenance.file_path}")
+
+        emitted = emit_models(normalize, output_dir=args.output_dir)
+        manifest = build_manifest(ingest=ingest, normalize=normalize, emit=emitted)
+
+        ingest_out = build_dir / "ingest.json"
+        normalize_out = build_dir / "normalize.json"
+        emit_out = build_dir / "emit.json"
+        manifest_out = build_dir / "manifest.json"
+        write_model(ingest_out, ingest)
+        write_model(normalize_out, normalize)
+        write_model(emit_out, emitted)
+        write_model(manifest_out, manifest)
+
+        manifest_schema = _schema_path(args.schema_dir, "manifest_schema.cue")
+        try:
+            validation = run_cue_validation(manifest_out, manifest_schema)
+        except CueUnavailableError as exc:
+            raise CodegenDiagnosticError("generate", str(exc)) from exc
+        _emit_validation("Post-generation manifest validation", validation)
+        if not validation.ok:
+            raise CodegenDiagnosticError("generate", "Manifest validation failed")
+
+        print(f"Wrote ingest artifact: {ingest_out}")
+        print(f"Wrote normalize artifact: {normalize_out}")
+        print(f"Wrote emit artifact: {emit_out}")
+        print(f"Wrote manifest artifact: {manifest_out}")
         return
 
     raise CodegenDiagnosticError("cli", f"Unsupported command: {args.command}")

--- a/src/pydantree/codegen/manifest.py
+++ b/src/pydantree/codegen/manifest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import platform
 from datetime import UTC, datetime
-from hashlib import sha256
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,26 +13,24 @@ from pydantree.codegen.normalize import NormalizeOutput
 class ReproducibilityManifest(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    input_hashes: dict[str, str]
+    toolchain_versions: dict[str, str]
+    output_file_hashes: dict[str, str]
     generated_at: datetime
-    pipeline_version: str
-    ingest_fingerprint: str
-    normalize_fingerprint: str
-    emit_fingerprint: str
-    query_count: int
-    module_count: int
 
 
 def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitOutput) -> ReproducibilityManifest:
+    del normalize
+
+    input_hashes = {query.provenance.file_path: query.provenance.source_sha256 for query in ingest.queries}
+    output_file_hashes = {module.file_path: module.content_sha256 for module in emit.modules}
+
     return ReproducibilityManifest(
+        input_hashes=dict(sorted(input_hashes.items())),
+        toolchain_versions={
+            "python": platform.python_version(),
+            "pydantree.codegen": "1",
+        },
+        output_file_hashes=dict(sorted(output_file_hashes.items())),
         generated_at=datetime.now(UTC),
-        pipeline_version="1",
-        ingest_fingerprint=_fingerprint(ingest.model_dump_json()),
-        normalize_fingerprint=_fingerprint(normalize.model_dump_json()),
-        emit_fingerprint=_fingerprint(emit.model_dump_json()),
-        query_count=len(normalize.queries),
-        module_count=len(emit.modules),
     )
-
-
-def _fingerprint(payload: str) -> str:
-    return sha256(payload.encode("utf-8")).hexdigest()

--- a/src/pydantree/doctor.py
+++ b/src/pydantree/doctor.py
@@ -168,7 +168,8 @@ def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[
                     )
                 )
 
-        for rel, expected_hash in manifest.get("generated_hashes", {}).items():
+        generated_hashes = manifest.get("output_file_hashes") or manifest.get("generated_hashes", {})
+        for rel, expected_hash in generated_hashes.items():
             generated_path = repo_root / rel
             if not generated_path.exists():
                 issues.append(

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -24,7 +24,8 @@ def test_pipeline_roundtrip(tmp_path: Path) -> None:
     assert len(ingest.queries) == 1
     assert len(normalize.queries[0].patterns) == 1
     assert len(emit.modules) == 1
-    assert manifest.query_count == 1
+    assert manifest.input_hashes["python/highlights.scm"] == ingest.queries[0].provenance.source_sha256
+    assert len(manifest.output_file_hashes) == 1
     assert (tmp_path / "generated" / "python_highlights_models.py").exists()
 
 

--- a/tests/test_cue_validation.py
+++ b/tests/test_cue_validation.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-from pathlib import Path
-
 from pydantree.cue_validation import _map_context
 
 
-def test_map_context_with_capture_information(tmp_path: Path) -> None:
-    ir_file = tmp_path / "ir.json"
-    ir_file.write_text(
-        '{"version":"v1","patterns":[{"pattern":"(function)","captures":[{"name":"function.name","source":{"file":"queries/highlights.scm"}}]}],"query_metadata":{"language":"python","query_type":"highlights","source_scm":"queries/highlights.scm"}}',
-        encoding="utf-8",
-    )
-
+def test_map_context_with_capture_information() -> None:
     ir_data = {
         "version": "v1",
         "patterns": [
@@ -34,3 +26,26 @@ def test_map_context_with_capture_information(tmp_path: Path) -> None:
 
     assert "capture=function.name" in mapped
     assert "scm=queries/highlights.scm" in mapped
+
+
+def test_map_context_with_pattern_capture_path() -> None:
+    ir_data = {
+        "version": "v1",
+        "patterns": [
+            {
+                "pattern": "(class_definition)",
+                "captures": [{"name": "class.name", "source": {"file": "queries/tags.scm"}}],
+            }
+        ],
+        "query_metadata": {
+            "language": "python",
+            "query_type": "tags",
+            "source_scm": "queries/tags.scm",
+        },
+    }
+
+    line = "ir.json: patterns[0].captures[0].name: invalid value"
+    mapped = _map_context(line, ir_data)
+
+    assert "capture=class.name" in mapped
+    assert "scm=queries/tags.scm" in mapped

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -39,7 +39,7 @@ def test_doctor_checks_manifest_and_generation_hashes(tmp_path: Path) -> None:
 
     manifest = {
         "input_hashes": {"queries/highlights.scm": "wrong"},
-        "generated_hashes": {"generated.py": "also-wrong"},
+        "output_file_hashes": {"generated.py": "also-wrong"},
     }
     manifest_path = tmp_path / "generated" / "manifest.json"
     manifest_path.parent.mkdir()
@@ -53,7 +53,7 @@ def test_doctor_checks_manifest_and_generation_hashes(tmp_path: Path) -> None:
 
     manifest_ok = {
         "input_hashes": {"queries/highlights.scm": _sha(input_contents)},
-        "generated_hashes": {"generated.py": hashlib.sha256(generated.read_bytes()).hexdigest()},
+        "output_file_hashes": {"generated.py": hashlib.sha256(generated.read_bytes()).hexdigest()},
     }
     manifest_path.write_text(json.dumps(manifest_ok), encoding="utf-8")
     result_ok = run_doctor(repo_root=tmp_path, queries_dir=queries, manifest_path=manifest_path)


### PR DESCRIPTION
### Motivation
- Make generation reproducible and validate IR/manifest artifacts with CUE gates to catch problems early. 
- Surface concise, actionable validation errors that map back to the original `.scm` source and capture names to speed debugging. 
- Include manifest-level provenance (input/output hashes and toolchain versions) to support deterministic builds and doctor's checks. 

### Description
- Add a `generate` subcommand to the `pydantree-codegen` CLI that runs `ingest` → `normalize` → per-query pre-generation CUE `vet` checks → `emit` → `manifest` → post-generation CUE `vet` check and writes stage artifacts to `--build-dir` (see `src/pydantree/codegen/cli.py`).
- Implement IR payload shaping for validation in `_query_ir_payload` so generated per-query IR JSON matches the IR CUE schema (`version`, `patterns`, `captures`, and `query_metadata`).
- Replace the previous manifest contract with a `ReproducibilityManifest` exposing `input_hashes`, `toolchain_versions`, and `output_file_hashes`, and update `build_manifest` to populate those fields (see `src/pydantree/codegen/manifest.py`).
- Improve CUE diagnostic mapping in `src/pydantree/cue_validation.py` by handling nested `patterns[i].captures[j]` paths and by hardening fallback behavior, so validation lines are annotated with `scm=<file>` and `capture=<name>` when available.
- Update `run_doctor` to prefer `output_file_hashes` while remaining backward-compatible with the legacy `generated_hashes` manifest key (see `src/pydantree/doctor.py`).
- Update tests and docs to cover the new wrapper and manifest/diagnostic behavior and add a README example for the single-command flow (files changed: `tests/test_cue_validation.py`, `tests/test_codegen_pipeline.py`, `tests/unit/test_doctor.py`, `README.md`).

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`14 passed`).
- Added unit tests for CUE error mapping (`tests/test_cue_validation.py`) and updated pipeline/doctor tests to assert the new manifest shape and hash checks; those tests succeeded.
- The `cue` CLI is not installed in this environment, so actual runtime invocation of `cue vet` could not be executed here, but the code uses `run_cue_validation` and will raise a clear error if `cue` is missing at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e130de228833396f85d7e345d5160)