### PR TITLE
Enhance doctor diagnostics for SCM and manifest drift

### DIFF
--- a/src/pydantree/doctor.py
+++ b/src/pydantree/doctor.py
@@ -56,6 +56,15 @@ def _discover_scm_files(queries_dir: Path) -> list[Path]:
 def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[str, Any]:
     issues: list[DoctorIssue] = []
 
+    if not queries_dir.exists():
+        issues.append(
+            DoctorIssue(
+                code="scm.missing_directory",
+                severity="warning",
+                message=f"Query directory does not exist: {queries_dir}.",
+            )
+        )
+
     scm_files = _discover_scm_files(queries_dir)
     if queries_dir.exists() and not scm_files:
         issues.append(
@@ -68,6 +77,7 @@ def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[
 
     capture_occurrences: dict[str, list[str]] = {}
     input_hashes: dict[str, str] = {}
+    discovered_files = {str(path.relative_to(repo_root)) for path in scm_files}
 
     for scm_file in scm_files:
         rel = str(scm_file.relative_to(repo_root))
@@ -96,7 +106,8 @@ def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[
                     )
                 )
 
-        for capture in _CAPTURE_PATTERN.findall(content):
+        file_captures = _CAPTURE_PATTERN.findall(content)
+        for capture in file_captures:
             capture_occurrences.setdefault(capture, []).append(rel)
             if not _VALID_CAPTURE_PATTERN.fullmatch(capture):
                 issues.append(
@@ -108,6 +119,18 @@ def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[
                         details={"capture": capture},
                     )
                 )
+
+        duplicates_in_file = sorted({name for name in file_captures if file_captures.count(name) > 1})
+        for duplicate_capture in duplicates_in_file:
+            issues.append(
+                DoctorIssue(
+                    code="capture.duplicate_in_file",
+                    severity="warning",
+                    message=f"Capture name '{duplicate_capture}' appears multiple times in a single file.",
+                    file=rel,
+                    details={"capture": duplicate_capture},
+                )
+            )
 
     for capture, files in sorted(capture_occurrences.items()):
         unique_files = sorted(set(files))
@@ -146,6 +169,15 @@ def run_doctor(repo_root: Path, queries_dir: Path, manifest_path: Path) -> dict[
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         manifest_inputs = manifest.get("input_hashes", {})
         for rel, expected_hash in manifest_inputs.items():
+            if rel not in discovered_files:
+                issues.append(
+                    DoctorIssue(
+                        code="scm.missing_file",
+                        severity="error",
+                        message=f"Manifest-referenced .scm file is missing from queries directory: '{rel}'.",
+                        file=rel,
+                    )
+                )
             actual_hash = input_hashes.get(rel)
             if actual_hash is None:
                 issues.append(

--- a/tests/unit/test_doctor.py
+++ b/tests/unit/test_doctor.py
@@ -23,8 +23,21 @@ def test_doctor_detects_empty_invalid_and_unsupported(tmp_path: Path) -> None:
     codes = {issue["code"] for issue in result["issues"]}
     assert "scm.empty_file" in codes
     assert "capture.invalid_name" in codes
+    assert "capture.duplicate_in_file" not in codes
     assert "query.unsupported_feature" in codes
     assert "manifest.not_found" in codes
+
+
+def test_doctor_detects_duplicate_capture_names_in_file(tmp_path: Path) -> None:
+    queries = tmp_path / "queries"
+    queries.mkdir()
+    (queries / "dup.scm").write_text("(identifier) @name (string) @name", encoding="utf-8")
+
+    result = run_doctor(repo_root=tmp_path, queries_dir=queries, manifest_path=tmp_path / "missing.json")
+
+    duplicate_issues = [issue for issue in result["issues"] if issue["code"] == "capture.duplicate_in_file"]
+    assert len(duplicate_issues) == 1
+    assert duplicate_issues[0]["file"] == "queries/dup.scm"
 
 
 def test_doctor_checks_manifest_and_generation_hashes(tmp_path: Path) -> None:
@@ -63,6 +76,29 @@ def test_doctor_checks_manifest_and_generation_hashes(tmp_path: Path) -> None:
         if issue["code"].startswith("manifest.") or issue["code"].startswith("generation.")
     }
     assert mismatch_codes == set()
+
+
+def test_doctor_detects_missing_manifest_referenced_input_file(tmp_path: Path) -> None:
+    queries = tmp_path / "queries"
+    queries.mkdir()
+    (queries / "highlights.scm").write_text("(identifier) @name", encoding="utf-8")
+
+    manifest = {
+        "input_hashes": {
+            "queries/highlights.scm": _sha("(identifier) @name"),
+            "queries/missing.scm": _sha("(string) @missing"),
+        },
+        "generated_hashes": {},
+    }
+    manifest_path = tmp_path / "generated" / "manifest.json"
+    manifest_path.parent.mkdir()
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = run_doctor(repo_root=tmp_path, queries_dir=queries, manifest_path=manifest_path)
+
+    issues_by_code = {issue["code"] for issue in result["issues"]}
+    assert "scm.missing_file" in issues_by_code
+    assert "manifest.missing_input" in issues_by_code
 
 
 def test_human_summary_renders() -> None:


### PR DESCRIPTION
### Motivation
- Improve the `doctor` diagnostics to catch common authoring and manifest drift issues earlier and more explicitly. 
- Surface both repository-layout problems and per-file issues so generation and runtime steps have clearer failure signals. 

### Description
- Add `scm.missing_directory` warning when the configured queries directory does not exist. 
- Add `capture.duplicate_in_file` warning when a single `.scm` file declares the same capture name multiple times, and keep existing `capture.invalid_name` and cross-file `capture.duplicate_name` checks. 
- Emit `scm.missing_file` error when the manifest references an input path that was not discovered under the queries directory while preserving `manifest.missing_input` and `manifest.input_hash_mismatch` behavior. 
- Maintain existing checks for unsupported query features, nondeterministic generation diffs (`generation.nondeterministic_diff`), manifest/generated hash mismatches, and missing runtime CLIs (`tree-sitter`, `cue`); output continues to be returned as machine-readable JSON and rendered human-readable summaries. 

### Testing
- Ran `pytest -q tests/unit/test_doctor.py` and the suite passed (`5 passed`). 
- Ran the full test suite with `pytest -q` and it passed (`15 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e13148d7c8333b769545ee6ce5255)