### PR TITLE
Add typed workshop event context and JSONL emissions across CLI workflows

### DIFF
--- a/src/pydantree/cli.py
+++ b/src/pydantree/cli.py
@@ -3,14 +3,29 @@ from __future__ import annotations
 import json
 import shlex
 import subprocess
+import time
 from pathlib import Path
+from uuid import uuid4
 
 import typer
 
 from pydantree.doctor import format_human_summary, run_doctor
 from pydantree.cue_validation import CueUnavailableError, run_cue_validation
+from pydantree.models import LogContext
+from pydantree.runtime import WorkshopEventLogger, build_log_context, hash_for_path
 
 app = typer.Typer(help="Pydantree generation wrappers with CUE validation gates.")
+
+
+
+
+def _context_for_path(path: Path, *, run_id: str) -> LogContext:
+    return build_log_context(
+        run_id=run_id,
+        language="unknown",
+        query_pack=path.stem,
+        source_hash=hash_for_path(path),
+    )
 
 
 @app.command("doctor")
@@ -56,14 +71,20 @@ def validate_ir(
     schema_dir: Path | None = typer.Option(None, help="Optional directory containing CUE schemas."),
 ) -> None:
     schema_file = _schema_path("ir_schema.cue", schema_dir)
+    logger = WorkshopEventLogger()
+    context = _context_for_path(ir_file, run_id=str(uuid4()))
     try:
         result = run_cue_validation(ir_file, schema_file)
     except CueUnavailableError as exc:
         typer.echo(str(exc))
+        logger.validation_failed(context, error=str(exc))
         raise typer.Exit(code=2) from exc
 
     _emit_validation_result("IR validation", result.ok, result.details)
-    if not result.ok:
+    if result.ok:
+        logger.validation_completed(context, checks_run=1)
+    else:
+        logger.validation_failed(context, error="; ".join(result.details) or "validation failed")
         raise typer.Exit(code=1)
 
 
@@ -73,14 +94,20 @@ def validate_manifest(
     schema_dir: Path | None = typer.Option(None, help="Optional directory containing CUE schemas."),
 ) -> None:
     schema_file = _schema_path("manifest_schema.cue", schema_dir)
+    logger = WorkshopEventLogger()
+    context = _context_for_path(manifest_file, run_id=str(uuid4()))
     try:
         result = run_cue_validation(manifest_file, schema_file)
     except CueUnavailableError as exc:
         typer.echo(str(exc))
+        logger.validation_failed(context, error=str(exc))
         raise typer.Exit(code=2) from exc
 
     _emit_validation_result("Manifest validation", result.ok, result.details)
-    if not result.ok:
+    if result.ok:
+        logger.validation_completed(context, checks_run=1)
+    else:
+        logger.validation_failed(context, error="; ".join(result.details) or "validation failed")
         raise typer.Exit(code=1)
 
 
@@ -93,29 +120,49 @@ def generate(
 ) -> None:
     ir_schema = _schema_path("ir_schema.cue", schema_dir)
     manifest_schema = _schema_path("manifest_schema.cue", schema_dir)
+    logger = WorkshopEventLogger()
+    run_id = str(uuid4())
+    context = _context_for_path(ir_file, run_id=run_id)
 
     try:
         pre_result = run_cue_validation(ir_file, ir_schema)
     except CueUnavailableError as exc:
         typer.echo(str(exc))
+        logger.validation_failed(context, error=str(exc))
         raise typer.Exit(code=2) from exc
 
     _emit_validation_result("Pre-generation IR validation", pre_result.ok, pre_result.details)
-    if not pre_result.ok:
+    if pre_result.ok:
+        logger.validation_completed(context, checks_run=1)
+    else:
+        logger.validation_failed(context, error="; ".join(pre_result.details) or "pre-generation validation failed")
         raise typer.Exit(code=1)
 
     command_parts = shlex.split(generator_cmd)
+    started = time.perf_counter()
     generation = subprocess.run(command_parts, check=False, text=True, capture_output=True)
+    elapsed_ms = int((time.perf_counter() - started) * 1000)
+    logger.query_runtime_execution(context, target=generator_cmd, elapsed_ms=elapsed_ms)
+
     if generation.stdout:
         typer.echo(generation.stdout.rstrip())
     if generation.returncode != 0:
         if generation.stderr:
             typer.echo(generation.stderr.rstrip())
+        logger.generation_failed(context, error=f"exit code {generation.returncode}")
         raise typer.Exit(code=generation.returncode)
+
+    logger.generation_completed(context, models_generated=1)
 
     post_result = run_cue_validation(manifest_file, manifest_schema)
     _emit_validation_result("Post-generation manifest validation", post_result.ok, post_result.details)
-    if not post_result.ok:
+    if post_result.ok:
+        logger.validation_completed(_context_for_path(manifest_file, run_id=run_id), checks_run=1)
+    else:
+        logger.validation_failed(
+            _context_for_path(manifest_file, run_id=run_id),
+            error="; ".join(post_result.details) or "post-generation validation failed",
+        )
         raise typer.Exit(code=1)
 
 

--- a/src/pydantree/codegen/cli.py
+++ b/src/pydantree/codegen/cli.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from uuid import uuid4
 
 from pydantree.codegen.common import CodegenDiagnosticError, read_model, write_model
 from pydantree.codegen.emit import EmitOutput, emit_models
 from pydantree.codegen.ingest import IngestOutput, ingest_scm
 from pydantree.codegen.manifest import build_manifest
 from pydantree.codegen.normalize import NormalizeOutput, normalize_ingested
+from pydantree.runtime import WorkshopEventLogger, build_log_context, hash_for_path
 
 
 def main() -> None:
@@ -19,8 +21,11 @@ def main() -> None:
         parser.print_help(sys.stderr)
         raise SystemExit(2)
 
+    logger = WorkshopEventLogger()
+    run_id = str(uuid4())
+
     try:
-        _dispatch(args)
+        _dispatch(args, logger=logger, run_id=run_id)
     except CodegenDiagnosticError as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(2) from exc
@@ -53,24 +58,54 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _dispatch(args: argparse.Namespace) -> None:
+def _dispatch(args: argparse.Namespace, *, logger: WorkshopEventLogger, run_id: str) -> None:
     if args.command == "ingest":
+        context = build_log_context(
+            run_id=run_id,
+            language="unknown",
+            query_pack="unknown",
+            source_hash=hash_for_path(args.root_dir),
+        )
+        logger.ingest_started(context)
         payload = ingest_scm(root_dir=args.root_dir, pattern=args.pattern)
         write_model(args.out, payload)
+        logger.ingest_completed(context, files_discovered=len(payload.queries))
         print(f"Wrote ingest artifact: {args.out}")
         return
 
     if args.command == "normalize":
         ingest = IngestOutput.model_validate(read_model(args.input_path, IngestOutput))
+        language = ingest.queries[0].provenance.language
+        query_pack = Path(ingest.queries[0].provenance.file_path).stem
+        context = build_log_context(
+            run_id=run_id,
+            language=language,
+            query_pack=query_pack,
+            source_hash=hash_for_path(args.input_path),
+        )
         normalized = normalize_ingested(ingest)
         write_model(args.out, normalized)
+        logger.normalize_completed(context, records_normalized=len(normalized.queries))
         print(f"Wrote normalize artifact: {args.out}")
         return
 
     if args.command == "emit":
         normalize = NormalizeOutput.model_validate(read_model(args.input_path, NormalizeOutput))
-        emitted = emit_models(normalize, output_dir=args.output_dir)
+        language = normalize.queries[0].provenance.language
+        query_pack = normalize.queries[0].provenance.query_type
+        context = build_log_context(
+            run_id=run_id,
+            language=language,
+            query_pack=query_pack,
+            source_hash=hash_for_path(args.input_path),
+        )
+        try:
+            emitted = emit_models(normalize, output_dir=args.output_dir)
+        except CodegenDiagnosticError as exc:
+            logger.generation_failed(context, error=str(exc))
+            raise
         write_model(args.out, emitted)
+        logger.generation_completed(context, models_generated=len(emitted.modules))
         print(f"Wrote emit artifact: {args.out}")
         return
 

--- a/src/pydantree/runtime/__init__.py
+++ b/src/pydantree/runtime/__init__.py
@@ -1,3 +1,3 @@
-from pydantree.runtime.workshop_logger import WorkshopEventLogger, resolve_tool_versions
+from pydantree.runtime.workshop_logger import WorkshopEventLogger, build_log_context, hash_for_path, resolve_tool_versions
 
-__all__ = ["WorkshopEventLogger", "resolve_tool_versions"]
+__all__ = ["WorkshopEventLogger", "build_log_context", "hash_for_path", "resolve_tool_versions"]

--- a/src/pydantree/runtime/workshop_logger.py
+++ b/src/pydantree/runtime/workshop_logger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from hashlib import sha256
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -8,6 +9,7 @@ from pydantree.models.log_events import (
     GenerationFailedEvent,
     IngestCompletedEvent,
     IngestStartedEvent,
+    LogContext,
     NormalizeCompletedEvent,
     QueryRuntimeExecutionEvent,
     ToolVersions,
@@ -23,6 +25,33 @@ def resolve_tool_versions() -> ToolVersions:
         pydantic=_safe_version("pydantic"),
         tree_sitter=_safe_version("tree-sitter"),
     )
+
+
+def build_log_context(*, run_id: str, language: str, query_pack: str, source_hash: str) -> LogContext:
+    return LogContext(
+        run_id=run_id,
+        language=language,
+        query_pack=query_pack,
+        source_hash=source_hash,
+        tool_versions=resolve_tool_versions(),
+    )
+
+
+def hash_for_path(path: Path) -> str:
+    if path.is_file():
+        return f"sha256:{sha256(path.read_bytes()).hexdigest()}"
+
+    if path.is_dir():
+        digest = sha256()
+        for nested in sorted(path.rglob("*")):
+            if nested.is_file():
+                digest.update(nested.relative_to(path).as_posix().encode("utf-8"))
+                digest.update(b"\n")
+                digest.update(nested.read_bytes())
+                digest.update(b"\n")
+        return f"sha256:{digest.hexdigest()}"
+
+    return "sha256:unknown"
 
 
 def _safe_version(package_name: str) -> str:
@@ -42,26 +71,26 @@ class WorkshopEventLogger:
             handle.write(event.model_dump_json())
             handle.write("\n")
 
-    def ingest_started(self, **kwargs: object) -> None:
-        self.emit(IngestStartedEvent(**kwargs))
+    def ingest_started(self, context: LogContext) -> None:
+        self.emit(IngestStartedEvent(**context.model_dump()))
 
-    def ingest_completed(self, **kwargs: object) -> None:
-        self.emit(IngestCompletedEvent(**kwargs))
+    def ingest_completed(self, context: LogContext, files_discovered: int) -> None:
+        self.emit(IngestCompletedEvent(**context.model_dump(), files_discovered=files_discovered))
 
-    def normalize_completed(self, **kwargs: object) -> None:
-        self.emit(NormalizeCompletedEvent(**kwargs))
+    def normalize_completed(self, context: LogContext, records_normalized: int) -> None:
+        self.emit(NormalizeCompletedEvent(**context.model_dump(), records_normalized=records_normalized))
 
-    def generation_completed(self, **kwargs: object) -> None:
-        self.emit(GenerationCompletedEvent(**kwargs))
+    def generation_completed(self, context: LogContext, models_generated: int) -> None:
+        self.emit(GenerationCompletedEvent(**context.model_dump(), models_generated=models_generated))
 
-    def generation_failed(self, **kwargs: object) -> None:
-        self.emit(GenerationFailedEvent(**kwargs))
+    def generation_failed(self, context: LogContext, error: str) -> None:
+        self.emit(GenerationFailedEvent(**context.model_dump(), error=error))
 
-    def validation_completed(self, **kwargs: object) -> None:
-        self.emit(ValidationCompletedEvent(**kwargs))
+    def validation_completed(self, context: LogContext, checks_run: int) -> None:
+        self.emit(ValidationCompletedEvent(**context.model_dump(), checks_run=checks_run))
 
-    def validation_failed(self, **kwargs: object) -> None:
-        self.emit(ValidationFailedEvent(**kwargs))
+    def validation_failed(self, context: LogContext, error: str) -> None:
+        self.emit(ValidationFailedEvent(**context.model_dump(), error=error))
 
-    def query_runtime_execution(self, **kwargs: object) -> None:
-        self.emit(QueryRuntimeExecutionEvent(**kwargs))
+    def query_runtime_execution(self, context: LogContext, target: str, elapsed_ms: int) -> None:
+        self.emit(QueryRuntimeExecutionEvent(**context.model_dump(), target=target, elapsed_ms=elapsed_ms))

--- a/tests/unit/test_workshop_logger.py
+++ b/tests/unit/test_workshop_logger.py
@@ -2,35 +2,30 @@ from __future__ import annotations
 
 import json
 
-from pydantree.runtime import WorkshopEventLogger
+from pydantree.runtime import WorkshopEventLogger, build_log_context
 
 
-def _base_payload() -> dict[str, object]:
-    return {
-        "run_id": "run-123",
-        "language": "python",
-        "query_pack": "core",
-        "source_hash": "sha256:abc",
-        "tool_versions": {
-            "pydantree": "0.1.0",
-            "pydantic": "2.11.0",
-            "tree_sitter": "0.23.0",
-        },
-    }
+def _base_context():
+    return build_log_context(
+        run_id="run-123",
+        language="python",
+        query_pack="core",
+        source_hash="sha256:abc",
+    )
 
 
 def test_logger_emits_all_workshop_events(tmp_path) -> None:
     logger = WorkshopEventLogger(tmp_path / "logs/workshop.jsonl")
-    payload = _base_payload()
+    context = _base_context()
 
-    logger.ingest_started(**payload)
-    logger.ingest_completed(**payload, files_discovered=2)
-    logger.normalize_completed(**payload, records_normalized=2)
-    logger.generation_completed(**payload, models_generated=1)
-    logger.generation_failed(**payload, error="codegen failed")
-    logger.validation_completed(**payload, checks_run=8)
-    logger.validation_failed(**payload, error="schema invalid")
-    logger.query_runtime_execution(**payload, target="fixtures/example.py", elapsed_ms=42)
+    logger.ingest_started(context)
+    logger.ingest_completed(context, files_discovered=2)
+    logger.normalize_completed(context, records_normalized=2)
+    logger.generation_completed(context, models_generated=1)
+    logger.generation_failed(context, error="codegen failed")
+    logger.validation_completed(context, checks_run=8)
+    logger.validation_failed(context, error="schema invalid")
+    logger.query_runtime_execution(context, target="fixtures/example.py", elapsed_ms=42)
 
     lines = (tmp_path / "logs/workshop.jsonl").read_text(encoding="utf-8").strip().splitlines()
 


### PR DESCRIPTION
### Motivation
- Provide a single, typed provenance context for pipeline events so every workshop log record includes `run_id`, `timestamp`, `language`, `query_pack`, `source_hash`, and tool versions. 
- Persist structured pipeline lifecycle events to `logs/workshop.jsonl` (JSONL) for observability of ingest/normalize/generation/validation and runtime execution.

### Description
- Added typed logging helpers in `src/pydantree/runtime/workshop_logger.py`: `build_log_context(...)`, `hash_for_path(...)`, and `resolve_tool_versions()` and changed `WorkshopEventLogger` methods to accept a `LogContext` and emit typed Pydantic events as JSONL. 
- Exported the new helpers from the runtime package via `src/pydantree/runtime/__init__.py` so CLI code can reuse the same context builder. 
- Instrumented the codegen CLI (`src/pydantree/codegen/cli.py`) to create a run `LogContext` and emit `ingest.started`, `ingest.completed`, `normalize.completed`, and `generation.completed`/`generation.failed` events (with failure path handling). 
- Instrumented the top-level CLI (`src/pydantree/cli.py`) to emit `validation.completed`/`validation.failed`, record `query.runtime.execution` timing (elapsed ms), and emit generation validation/generation events using the same `LogContext`. 
- Updated `tests/unit/test_workshop_logger.py` to build and pass a `LogContext` and verify the full event sequence is emitted to `logs/workshop.jsonl`.

### Testing
- Ran unit tests: `pytest -q tests/unit/test_workshop_logger.py tests/unit/test_registry_layout.py tests/unit/test_doctor.py` and all passed. 
- Ran full test suite: `pytest -q` and all tests passed. 
- Verified the updated workshop logger unit test specifically with `pytest -q tests/unit/test_workshop_logger.py` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e132478b08333b3310a8131fc9665)