### PR TITLE
Stabilize codegen manifest generation and tests

### DIFF
--- a/src/pydantree/codegen/manifest.py
+++ b/src/pydantree/codegen/manifest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import platform
 import json
+from hashlib import sha256
 from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict
@@ -15,15 +16,19 @@ from pydantree.codegen.normalize import NormalizeOutput
 class ReproducibilityManifest(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    pipeline_version: str
     input_hashes: dict[str, str]
     toolchain_versions: dict[str, str]
     output_file_hashes: dict[str, str]
+    ingest_fingerprint: str
+    normalize_fingerprint: str
+    emit_fingerprint: str
+    query_count: int
+    module_count: int
     generated_at: datetime
 
 
 def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitOutput) -> ReproducibilityManifest:
-    del normalize
-
     input_hashes = {query.provenance.file_path: query.provenance.source_sha256 for query in ingest.queries}
     output_file_hashes = {module.file_path: module.content_sha256 for module in emit.modules}
     if len(ingest.queries) != len(normalize.queries):
@@ -40,21 +45,20 @@ def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitO
         )
 
     return ReproducibilityManifest(
+        pipeline_version="2",
         input_hashes=dict(sorted(input_hashes.items())),
         toolchain_versions={
             "python": platform.python_version(),
             "pydantree.codegen": "1",
         },
         output_file_hashes=dict(sorted(output_file_hashes.items())),
+        ingest_fingerprint=_fingerprint(ingest.model_dump(mode="json")),
+        normalize_fingerprint=_fingerprint(normalize.model_dump(mode="json")),
+        emit_fingerprint=_fingerprint(emit.model_dump(mode="json")),
+        query_count=len(normalize.queries),
+        module_count=len(emit.modules),
         generated_at=datetime.now(UTC),
     )
-#         pipeline_version="2",
-#         ingest_fingerprint=_fingerprint(ingest.model_dump(mode="json")),
-#         normalize_fingerprint=_fingerprint(normalize.model_dump(mode="json")),
-#         emit_fingerprint=_fingerprint(emit.model_dump(mode="json")),
-#         query_count=len(normalize.queries),
-#         module_count=len(emit.modules),
-#     )
 
 
 def _fingerprint(payload: object) -> str:

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -29,7 +29,11 @@ def test_pipeline_roundtrip(tmp_path: Path) -> None:
     assert manifest.input_hashes["python/highlights.scm"] == ingest.queries[0].provenance.source_sha256
     assert len(manifest.output_file_hashes) == 1
     assert manifest.query_count == 1
+    assert manifest.module_count == 1
     assert manifest.pipeline_version == "2"
+    assert manifest.ingest_fingerprint
+    assert manifest.normalize_fingerprint
+    assert manifest.emit_fingerprint
     assert (tmp_path / "generated" / "python_highlights_models.py").exists()
 
 
@@ -61,3 +65,16 @@ def test_manifest_fails_with_mismatched_emit_payload(tmp_path: Path) -> None:
 
     with pytest.raises(CodegenDiagnosticError, match="Normalize and emit counts do not match"):
         build_manifest(ingest, normalize, emit.model_copy(update={"modules": tuple()}))
+
+
+def test_manifest_fails_with_mismatched_normalize_payload(tmp_path: Path) -> None:
+    query_dir = tmp_path / "queries" / "python"
+    query_dir.mkdir(parents=True)
+    (query_dir / "highlights.scm").write_text("(identifier) @id\n", encoding="utf-8")
+
+    ingest = ingest_scm(tmp_path / "queries")
+    normalize = normalize_ingested(ingest)
+    emit = emit_models(normalize, tmp_path / "generated")
+
+    with pytest.raises(CodegenDiagnosticError, match="Ingest and normalize query counts do not match"):
+        build_manifest(ingest, normalize.model_copy(update={"queries": tuple()}), emit)


### PR DESCRIPTION
### Motivation

- Ensure manifest generation is internally consistent by using the `normalize` payload for count checks and emitting the same fields consumers expect.  
- Re-enable reproducibility metadata (fingerprints, counts, pipeline version) so manifests are useful for validation and debugging.  
- Keep manifest keys compatible with downstream consumers and schema (`input_hashes`, `output_file_hashes`, etc.).

### Description

- Removed the `del normalize` no-op and kept both stage-count consistency checks (`ingest` vs `normalize` and `normalize` vs `emit`) in `build_manifest`.  
- Restored previously commented manifest fields on `ReproducibilityManifest` and populated them in `build_manifest`: `pipeline_version`, `ingest_fingerprint`, `normalize_fingerprint`, `emit_fingerprint`, `query_count`, and `module_count`.  
- Imported `sha256` from `hashlib` and wired the active `_fingerprint()` function to produce JSON-stable SHA256 fingerprints for stage artifacts.  
- Left canonical keys unchanged (`input_hashes`, `output_file_hashes`, `toolchain_versions`, `generated_at`) to preserve compatibility with `doctor.py` and the manifest CUE schema.  
- Updated tests in `tests/test_codegen_pipeline.py` to assert the restored manifest fields and added a new test for the ingest-vs-normalize count-mismatch error path.

### Testing

- Ran `pytest -q tests/test_codegen_pipeline.py tests/unit/test_doctor.py` and all tests passed (`10 passed`).  
- Existing doctor unit tests were left compatible because manifest key names were preserved.  
- Added a new pipeline test `test_manifest_fails_with_mismatched_normalize_payload` and updated `test_pipeline_roundtrip` to validate fingerprint and count fields.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e19342b3c8333af408a64ae08ba75)