### PR TITLE
Unify codegen CLI and just contract on language/query-pack args

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ PYTHONPATH=src python -m pydantree.codegen.cli ingest python minimal_pack
 PYTHONPATH=src python -m pydantree.codegen.cli normalize python minimal_pack
 ```
 
+Default artifacts are written to:
+- `build/python/minimal_pack/ingest.json`
+- `workshop/ir/python/minimal_pack/ir.v1.json`
+
 ### 3) Generate baseclasses/models
 
 Emit deterministic Pydantic query model modules into the canonical generated layout.
@@ -108,6 +112,9 @@ Emit deterministic Pydantic query model modules into the canonical generated lay
 ```bash
 PYTHONPATH=src python -m pydantree.codegen.cli emit python minimal_pack
 ```
+
+Default emit artifact:
+- `build/python/minimal_pack/emit.json`
 
 Expected generated module path for this minimal pack:
 

--- a/justfile
+++ b/justfile
@@ -65,7 +65,6 @@ language = sys.argv[2]
 query_pack = sys.argv[3]
 layout = WorkshopLayout.from_path(repo_root)
 
-pack_dir = layout.queries_pack_dir(language, query_pack)
 out_file = repo_root / "build" / language / query_pack / "ingest.json"
 out_file.parent.mkdir(parents=True, exist_ok=True)
 
@@ -75,9 +74,8 @@ subprocess.run(
         "-m",
         "pydantree.codegen.cli",
         "ingest",
-        str(pack_dir),
-        "--out",
-        str(out_file),
+        language,
+        query_pack,
     ],
     check=True,
     cwd=repo_root,
@@ -89,7 +87,6 @@ PY
 generate-models language query_pack:
 	PYTHONPATH="{{repo_root}}/src" python - <<'PY' "{{repo_root}}" "{{language}}" "{{query_pack}}"
 from pathlib import Path
-import shutil
 import subprocess
 import sys
 
@@ -110,7 +107,7 @@ models_dir = layout.generated_models_dir(language, query_pack)
 manifest_path.parent.mkdir(parents=True, exist_ok=True)
 
 subprocess.run(
-    [sys.executable, "-m", "pydantree.codegen.cli", "normalize", "--input", str(ingest_path), "--out", str(normalize_path)],
+    [sys.executable, "-m", "pydantree.codegen.cli", "normalize", language, query_pack],
     check=True,
     cwd=repo_root,
 )
@@ -120,12 +117,8 @@ subprocess.run(
         "-m",
         "pydantree.codegen.cli",
         "emit",
-        "--input",
-        str(normalize_path),
-        "--output-dir",
-        str(models_dir),
-        "--out",
-        str(emit_path),
+        language,
+        query_pack,
     ],
     check=True,
     cwd=repo_root,
@@ -136,24 +129,14 @@ subprocess.run(
         "-m",
         "pydantree.codegen.cli",
         "manifest",
-        "--ingest",
-        str(ingest_path),
-        "--normalize",
-        str(normalize_path),
-        "--emit",
-        str(emit_path),
-        "--out",
-        str(manifest_path),
+        language,
+        query_pack,
     ],
     check=True,
     cwd=repo_root,
 )
-
-ir_path = layout.ir_file(language, query_pack)
-ir_path.parent.mkdir(parents=True, exist_ok=True)
-shutil.copyfile(normalize_path, ir_path)
 print(f"Generated models: {models_dir.relative_to(repo_root)}")
-print(f"IR artifact: {ir_path.relative_to(repo_root)}")
+print(f"IR artifact: {normalize_path.relative_to(repo_root)}")
 print(f"Manifest: {manifest_path.relative_to(repo_root)}")
 PY
 

--- a/src/pydantree/codegen/cli.py
+++ b/src/pydantree/codegen/cli.py
@@ -4,14 +4,12 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from uuid import uuid4
 
 from pydantree.codegen.common import CodegenDiagnosticError, read_model, write_model
 from pydantree.codegen.emit import EmitOutput, emit_models
 from pydantree.codegen.ingest import IngestOutput, ingest_scm
 from pydantree.codegen.manifest import build_manifest
-from pydantree.codegen.normalize import NormalizeOutput, normalize_ingested
-from pydantree.runtime import WorkshopEventLogger, build_log_context, hash_for_path
+from pydantree.codegen.normalize import NormalizeOutput, NormalizedQuery, normalize_ingested
 from pydantree.cue_validation import CueUnavailableError, ValidationResult, run_cue_validation
 from pydantree.registry import WorkshopLayout, resolve_repository_root
 
@@ -24,11 +22,8 @@ def main() -> None:
         parser.print_help(sys.stderr)
         raise SystemExit(2)
 
-    logger = WorkshopEventLogger()
-    run_id = str(uuid4())
-
     try:
-        _dispatch(args, logger=logger, run_id=run_id)
+        _dispatch(args)
     except CodegenDiagnosticError as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(2) from exc
@@ -78,97 +73,12 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _dispatch(args: argparse.Namespace, *, logger: WorkshopEventLogger, run_id: str) -> None:
-    if args.command == "ingest":
-        context = build_log_context(
-            run_id=run_id,
-            language="unknown",
-            query_pack="unknown",
-            source_hash=hash_for_path(args.root_dir),
-        )
-        logger.ingest_started(context)
-        payload = ingest_scm(root_dir=args.root_dir, pattern=args.pattern)
-        write_model(args.out, payload)
-        logger.ingest_completed(context, files_discovered=len(payload.queries))
-        print(f"Wrote ingest artifact: {args.out}")
-        return
-
-    if args.command == "normalize":
-        ingest = IngestOutput.model_validate(read_model(args.input_path, IngestOutput))
-        language = ingest.queries[0].provenance.language
-        query_pack = Path(ingest.queries[0].provenance.file_path).stem
-        context = build_log_context(
-            run_id=run_id,
-            language=language,
-            query_pack=query_pack,
-            source_hash=hash_for_path(args.input_path),
-        )
-        normalized = normalize_ingested(ingest)
-        write_model(args.out, normalized)
-        logger.normalize_completed(context, records_normalized=len(normalized.queries))
-        print(f"Wrote normalize artifact: {args.out}")
-        return
-
-    if args.command == "emit":
-        normalize = NormalizeOutput.model_validate(read_model(args.input_path, NormalizeOutput))
-        language = normalize.queries[0].provenance.language
-        query_pack = normalize.queries[0].provenance.query_type
-        context = build_log_context(
-            run_id=run_id,
-            language=language,
-            query_pack=query_pack,
-            source_hash=hash_for_path(args.input_path),
-        )
-        try:
-            emitted = emit_models(normalize, output_dir=args.output_dir)
-        except CodegenDiagnosticError as exc:
-            logger.generation_failed(context, error=str(exc))
-            raise
-        write_model(args.out, emitted)
-        logger.generation_completed(context, models_generated=len(emitted.modules))
-        print(f"Wrote emit artifact: {args.out}")
-def _schema_path(schema_dir: Path, name: str) -> Path:
-    return schema_dir / name
-
-
-def _emit_validation(result_name: str, result: ValidationResult) -> None:
-    if result.ok:
-        print(f"{result_name}: ok")
-        return
-    print(f"{result_name}: failed", file=sys.stderr)
-    for detail in result.details:
-        print(f"  - {detail}", file=sys.stderr)
-
-
-def _query_ir_payload(query: object) -> dict[str, object]:
-    from pydantree.codegen.normalize import NormalizedQuery
-
-    normalized = NormalizedQuery.model_validate(query)
-    return {
-        "version": "v1",
-        "patterns": [
-            {
-                "id": pattern.pattern_id,
-                "pattern": pattern.source,
-                "captures": [
-                    {
-                        "name": capture.name,
-                        "source": {"file": normalized.provenance.file_path},
-                    }
-                    for capture in pattern.captures
-                ],
-            }
-            for pattern in normalized.patterns
-        ],
-        "query_metadata": {
-            "language": normalized.provenance.language,
-            "query_type": normalized.provenance.query_type,
-            "source_scm": normalized.provenance.file_path,
-            "generated_by": "pydantree-codegen",
-        },
-    }
 def _layout() -> WorkshopLayout:
     return WorkshopLayout.from_path(resolve_repository_root())
+
+
+def _stage_file(layout: WorkshopLayout, *, language: str, query_pack: str, stage: str) -> Path:
+    return layout.repository_root / "build" / language / query_pack / f"{stage}.json"
 
 
 def _dispatch(args: argparse.Namespace) -> None:
@@ -176,14 +86,19 @@ def _dispatch(args: argparse.Namespace) -> None:
 
     if args.command == "ingest":
         root_dir = layout.queries_pack_dir(language=args.language, query_pack=args.query_pack)
-        out = args.out or (layout.repository_root / "build" / f"ingest.{args.language}.{args.query_pack}.json")
+        out = args.out or _stage_file(layout, language=args.language, query_pack=args.query_pack, stage="ingest")
         payload = ingest_scm(root_dir=root_dir, pattern=args.pattern)
         write_model(out, payload)
         print(f"Wrote ingest artifact: {out}")
         return
 
     if args.command == "normalize":
-        input_path = args.input_path or (layout.repository_root / "build" / f"ingest.{args.language}.{args.query_pack}.json")
+        input_path = args.input_path or _stage_file(
+            layout,
+            language=args.language,
+            query_pack=args.query_pack,
+            stage="ingest",
+        )
         out = args.out or layout.ir_file(language=args.language, query_pack=args.query_pack)
         ingest = IngestOutput.model_validate(read_model(input_path, IngestOutput))
         normalized = normalize_ingested(ingest)
@@ -194,7 +109,7 @@ def _dispatch(args: argparse.Namespace) -> None:
     if args.command == "emit":
         input_path = args.input_path or layout.ir_file(language=args.language, query_pack=args.query_pack)
         output_dir = args.output_dir or layout.generated_models_dir(language=args.language, query_pack=args.query_pack)
-        out = args.out or (layout.repository_root / "build" / f"emit.{args.language}.{args.query_pack}.json")
+        out = args.out or _stage_file(layout, language=args.language, query_pack=args.query_pack, stage="emit")
         normalize = NormalizeOutput.model_validate(read_model(input_path, NormalizeOutput))
         emitted = emit_models(normalize, output_dir=output_dir)
         write_model(out, emitted)
@@ -202,9 +117,14 @@ def _dispatch(args: argparse.Namespace) -> None:
         return
 
     if args.command == "manifest":
-        ingest_path = args.ingest_path or (layout.repository_root / "build" / f"ingest.{args.language}.{args.query_pack}.json")
+        ingest_path = args.ingest_path or _stage_file(
+            layout,
+            language=args.language,
+            query_pack=args.query_pack,
+            stage="ingest",
+        )
         normalize_path = args.normalize_path or layout.ir_file(language=args.language, query_pack=args.query_pack)
-        emit_path = args.emit_path or (layout.repository_root / "build" / f"emit.{args.language}.{args.query_pack}.json")
+        emit_path = args.emit_path or _stage_file(layout, language=args.language, query_pack=args.query_pack, stage="emit")
         out = args.out or layout.manifest_file(language=args.language, query_pack=args.query_pack)
         ingest = IngestOutput.model_validate(read_model(ingest_path, IngestOutput))
         normalize = NormalizeOutput.model_validate(read_model(normalize_path, NormalizeOutput))
@@ -261,6 +181,46 @@ def _dispatch(args: argparse.Namespace) -> None:
         return
 
     raise CodegenDiagnosticError("cli", f"Unsupported command: {args.command}")
+
+
+def _schema_path(schema_dir: Path, name: str) -> Path:
+    return schema_dir / name
+
+
+def _emit_validation(result_name: str, result: ValidationResult) -> None:
+    if result.ok:
+        print(f"{result_name}: ok")
+        return
+    print(f"{result_name}: failed", file=sys.stderr)
+    for detail in result.details:
+        print(f"  - {detail}", file=sys.stderr)
+
+
+def _query_ir_payload(query: object) -> dict[str, object]:
+    normalized = NormalizedQuery.model_validate(query)
+    return {
+        "version": "v1",
+        "patterns": [
+            {
+                "id": pattern.pattern_id,
+                "pattern": pattern.source,
+                "captures": [
+                    {
+                        "name": capture.name,
+                        "source": {"file": normalized.provenance.file_path},
+                    }
+                    for capture in pattern.captures
+                ],
+            }
+            for pattern in normalized.patterns
+        ],
+        "query_metadata": {
+            "language": normalized.provenance.language,
+            "query_type": normalized.provenance.query_type,
+            "source_scm": normalized.provenance.file_path,
+            "generated_by": "pydantree-codegen",
+        },
+    }
 
 
 if __name__ == "__main__":

--- a/src/pydantree/codegen/manifest.py
+++ b/src/pydantree/codegen/manifest.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import platform
 import json
+import platform
+from hashlib import sha256
 from datetime import UTC, datetime
 
 from pydantic import BaseModel, ConfigDict
@@ -18,12 +19,13 @@ class ReproducibilityManifest(BaseModel):
     input_hashes: dict[str, str]
     toolchain_versions: dict[str, str]
     output_file_hashes: dict[str, str]
+    pipeline_version: str
+    query_count: int
+    module_count: int
     generated_at: datetime
 
 
 def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitOutput) -> ReproducibilityManifest:
-    del normalize
-
     input_hashes = {query.provenance.file_path: query.provenance.source_sha256 for query in ingest.queries}
     output_file_hashes = {module.file_path: module.content_sha256 for module in emit.modules}
     if len(ingest.queries) != len(normalize.queries):
@@ -46,15 +48,11 @@ def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitO
             "pydantree.codegen": "1",
         },
         output_file_hashes=dict(sorted(output_file_hashes.items())),
+        pipeline_version="2",
+        query_count=len(normalize.queries),
+        module_count=len(emit.modules),
         generated_at=datetime.now(UTC),
     )
-#         pipeline_version="2",
-#         ingest_fingerprint=_fingerprint(ingest.model_dump(mode="json")),
-#         normalize_fingerprint=_fingerprint(normalize.model_dump(mode="json")),
-#         emit_fingerprint=_fingerprint(emit.model_dump(mode="json")),
-#         query_count=len(normalize.queries),
-#         module_count=len(emit.modules),
-#     )
 
 
 def _fingerprint(payload: object) -> str:

--- a/tests/test_codegen_cli_integration.py
+++ b/tests/test_codegen_cli_integration.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantree.codegen import cli
+from pydantree.registry import WorkshopLayout
+
+
+def test_cli_name_contract_pipeline_via_parsed_args(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "pydantree"\n', encoding="utf-8")
+
+    layout = WorkshopLayout.from_path(tmp_path)
+    query_dir = layout.queries_pack_dir("python", "minimal_pack")
+    query_dir.mkdir(parents=True)
+    (query_dir / "highlights.scm").write_text("(identifier) @id\n", encoding="utf-8")
+
+    monkeypatch.chdir(tmp_path)
+    parser = cli._build_parser()
+
+    for argv in (
+        ["ingest", "python", "minimal_pack"],
+        ["normalize", "python", "minimal_pack"],
+        ["emit", "python", "minimal_pack"],
+        ["manifest", "python", "minimal_pack"],
+    ):
+        args = parser.parse_args(argv)
+        cli._dispatch(args)
+
+    ingest_path = tmp_path / "build" / "python" / "minimal_pack" / "ingest.json"
+    emit_path = tmp_path / "build" / "python" / "minimal_pack" / "emit.json"
+    ir_path = layout.ir_file("python", "minimal_pack")
+    models_dir = layout.generated_models_dir("python", "minimal_pack")
+    manifest_path = layout.manifest_file("python", "minimal_pack")
+
+    assert ingest_path.exists()
+    assert emit_path.exists()
+    assert ir_path.exists()
+    assert manifest_path.exists()
+    generated_modules = list(models_dir.glob("*_highlights_models.py"))
+    assert generated_modules
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["query_count"] == 1


### PR DESCRIPTION
### Motivation
- Ensure a single, shell-first public contract so `just` recipes and the codegen CLI agree on naming semantics (`language` + `query_pack`) rather than exchanging raw filesystem paths.
- Make default artifact paths deterministic and discoverable by aligning CLI defaults with `WorkshopLayout` (workshop/build layout) so tooling and docs rely on the same locations.
- Improve developer confidence by adding an integration test that exercises the full `ingest -> normalize -> emit -> manifest` chain via parsed CLI args.

### Description
- Standardized the codegen CLI (`ingest`, `normalize`, `emit`, `manifest`) to accept name-based positionals `language` and `query_pack` in `_build_parser()` and updated the single `_dispatch(args)` implementation to resolve canonical paths via `WorkshopLayout` and a `_stage_file()` helper.
- Updated `justfile` recipes (`ingest`, `generate-models`, etc.) to invoke the CLI using `language` and `query_pack` positionals instead of passing repository paths, and removed redundant path-copying logic.
- Aligned README quickstart examples to document the chosen contract and the default artifact locations produced by the CLI (e.g. `build/<language>/<query_pack>/ingest.json`, `workshop/ir/<language>/<query_pack>/ir.v1.json`, `workshop/manifests/<language>/<query_pack>.json`).
- Enhanced the manifest model to include `pipeline_version`, `query_count`, and `module_count`, and restored the `sha256` usage required by helper fingerprinting logic to maintain manifest consistency.
- Added `tests/test_codegen_cli_integration.py` which constructs a minimal workshop layout under `tmp_path`, runs parsed CLI subcommands (`ingest`, `normalize`, `emit`, `manifest`), and asserts that the expected artifacts and generated modules exist.

### Testing
- Ran `pytest -q tests/test_codegen_cli_integration.py tests/test_codegen_pipeline.py tests/unit/test_registry_layout.py` and all tests passed successfully.
- The new integration test exercises the full `ingest -> normalize -> emit -> manifest` flow via `cli._build_parser()` and `cli._dispatch()` and asserts canonical artifact creation.
- Existing unit and pipeline tests were executed to validate `WorkshopLayout` path helpers, ingest/normalize/emit/manifest pipeline behavior, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e192b56bc83339266d5604646b360)