### PR TITLE
Align and codify reproducibility manifest contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Pydantree uses a canonical on-disk layout so generation, manifests, and runtime 
 - `workshop/queries/<language>/<query_pack>/*.scm` (source of truth)
 - `workshop/ir/<language>/<query_pack>/ir.v1.json`
 - `src/pydantree/generated/<language>/<query_pack>/`
-- `workshop/manifests/<language>/<query_pack>.json` (hashes, tool versions, source refs)
+- `workshop/manifests/<language>/<query_pack>.json` (`pipeline_version`, `input_hashes`, `toolchain_versions`, `output_file_hashes`, `ingest_fingerprint`, `normalize_fingerprint`, `emit_fingerprint`, `query_count`, `module_count`, `generated_at`)
 - `logs/workshop.jsonl` (append-only event log)
 
 Use `pydantree.registry.WorkshopLayout` path helpers so CLI and recipes can accept only logical names (`language`, `query_pack`) and avoid hard-coded paths.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,7 +45,7 @@ This roadmap describes a practical, step-by-step path to build a focused **Tree-
 
 1. Create deterministic codegen templates for query and result models.
 2. Emit generated modules by language/query type.
-3. Write a generation manifest (hashes + source revisions) to support reproducible builds.
+3. Write a generation manifest (hashes, stage fingerprints, counts, tool versions, and timestamp) to support reproducible builds.
 4. Ensure generation is idempotent (same inputs => byte-identical outputs).
 
 ## 6) Implement runtime query execution

--- a/src/pydantree/codegen/cli.py
+++ b/src/pydantree/codegen/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from uuid import uuid4
 from pathlib import Path
 
 from pydantree.codegen.common import CodegenDiagnosticError, read_model, write_model
@@ -12,6 +13,7 @@ from pydantree.codegen.manifest import build_manifest
 from pydantree.codegen.normalize import NormalizeOutput, NormalizedQuery, normalize_ingested
 from pydantree.cue_validation import CueUnavailableError, ValidationResult, run_cue_validation
 from pydantree.registry import WorkshopLayout, resolve_repository_root
+from pydantree.runtime import WorkshopEventLogger, build_log_context, hash_for_path
 
 
 def main() -> None:
@@ -23,7 +25,7 @@ def main() -> None:
         raise SystemExit(2)
 
     try:
-        _dispatch(args)
+        _dispatch(args, logger=WorkshopEventLogger(), run_id=str(uuid4()))
     except CodegenDiagnosticError as exc:
         print(str(exc), file=sys.stderr)
         raise SystemExit(2) from exc
@@ -81,14 +83,12 @@ def _stage_file(layout: WorkshopLayout, *, language: str, query_pack: str, stage
     return layout.repository_root / "build" / language / query_pack / f"{stage}.json"
 
 
-# def _dispatch(args: argparse.Namespace) -> None:
 def _dispatch(args: argparse.Namespace, *, logger: WorkshopEventLogger, run_id: str) -> None:
     layout = _layout()
 
     if args.command == "ingest":
         root_dir = layout.queries_pack_dir(language=args.language, query_pack=args.query_pack)
-#         out = args.out or _stage_file(layout, language=args.language, query_pack=args.query_pack, stage="ingest")
-        out = args.out or (layout.repository_root / "build" / f"ingest.{args.language}.{args.query_pack}.json")
+        out = args.out or _stage_file(layout, language=args.language, query_pack=args.query_pack, stage="ingest")
         context = build_log_context(
             run_id=run_id,
             language=args.language,

--- a/src/pydantree/codegen/manifest.py
+++ b/src/pydantree/codegen/manifest.py
@@ -20,7 +20,6 @@ class ReproducibilityManifest(BaseModel):
     input_hashes: dict[str, str]
     toolchain_versions: dict[str, str]
     output_file_hashes: dict[str, str]
-    pipeline_version: str
     ingest_fingerprint: str
     normalize_fingerprint: str
     emit_fingerprint: str
@@ -53,7 +52,6 @@ def build_manifest(ingest: IngestOutput, normalize: NormalizeOutput, emit: EmitO
             "pydantree.codegen": "1",
         },
         output_file_hashes=dict(sorted(output_file_hashes.items())),
-        pipeline_version="2",
         ingest_fingerprint=_fingerprint(ingest.model_dump(mode="json")),
         normalize_fingerprint=_fingerprint(normalize.model_dump(mode="json")),
         emit_fingerprint=_fingerprint(emit.model_dump(mode="json")),

--- a/src/pydantree/cue/manifest_schema.cue
+++ b/src/pydantree/cue/manifest_schema.cue
@@ -1,8 +1,14 @@
 package pydantree
 
 #Manifest: {
+    pipeline_version: string
     input_hashes: [string]: string
     toolchain_versions: [string]: string
     output_file_hashes: [string]: string
-    generated_at?: string
+    ingest_fingerprint: string
+    normalize_fingerprint: string
+    emit_fingerprint: string
+    query_count: int
+    module_count: int
+    generated_at: string
 }

--- a/tests/test_codegen_cli_integration.py
+++ b/tests/test_codegen_cli_integration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from pydantree.codegen import cli
 from pydantree.registry import WorkshopLayout
+from pydantree.runtime import WorkshopEventLogger
 
 
 def test_cli_name_contract_pipeline_via_parsed_args(tmp_path: Path, monkeypatch) -> None:
@@ -25,7 +26,7 @@ def test_cli_name_contract_pipeline_via_parsed_args(tmp_path: Path, monkeypatch)
         ["manifest", "python", "minimal_pack"],
     ):
         args = parser.parse_args(argv)
-        cli._dispatch(args)
+        cli._dispatch(args, logger=WorkshopEventLogger(), run_id="test-run")
 
     ingest_path = tmp_path / "build" / "python" / "minimal_pack" / "ingest.json"
     emit_path = tmp_path / "build" / "python" / "minimal_pack" / "emit.json"

--- a/tests/test_codegen_pipeline.py
+++ b/tests/test_codegen_pipeline.py
@@ -31,9 +31,9 @@ def test_pipeline_roundtrip(tmp_path: Path) -> None:
     assert manifest.query_count == 1
     assert manifest.module_count == 1
     assert manifest.pipeline_version == "2"
-    assert manifest.ingest_fingerprint
-    assert manifest.normalize_fingerprint
-    assert manifest.emit_fingerprint
+    assert len(manifest.ingest_fingerprint) == 64
+    assert len(manifest.normalize_fingerprint) == 64
+    assert len(manifest.emit_fingerprint) == 64
     assert (tmp_path / "generated" / "python_highlights_models.py").exists()
 
 
@@ -78,3 +78,38 @@ def test_manifest_fails_with_mismatched_normalize_payload(tmp_path: Path) -> Non
 
     with pytest.raises(CodegenDiagnosticError, match="Ingest and normalize query counts do not match"):
         build_manifest(ingest, normalize.model_copy(update={"queries": tuple()}), emit)
+
+
+def test_manifest_serialized_contract_keys_and_types(tmp_path: Path) -> None:
+    query_dir = tmp_path / "queries" / "python"
+    query_dir.mkdir(parents=True)
+    (query_dir / "highlights.scm").write_text("(identifier) @id\n", encoding="utf-8")
+
+    ingest = ingest_scm(tmp_path / "queries")
+    normalize = normalize_ingested(ingest)
+    emit = emit_models(normalize, tmp_path / "generated")
+
+    payload = build_manifest(ingest, normalize, emit).model_dump(mode="json")
+
+    assert set(payload) == {
+        "pipeline_version",
+        "input_hashes",
+        "toolchain_versions",
+        "output_file_hashes",
+        "ingest_fingerprint",
+        "normalize_fingerprint",
+        "emit_fingerprint",
+        "query_count",
+        "module_count",
+        "generated_at",
+    }
+    assert isinstance(payload["pipeline_version"], str)
+    assert isinstance(payload["input_hashes"], dict)
+    assert isinstance(payload["toolchain_versions"], dict)
+    assert isinstance(payload["output_file_hashes"], dict)
+    assert isinstance(payload["ingest_fingerprint"], str)
+    assert isinstance(payload["normalize_fingerprint"], str)
+    assert isinstance(payload["emit_fingerprint"], str)
+    assert isinstance(payload["query_count"], int)
+    assert isinstance(payload["module_count"], int)
+    assert isinstance(payload["generated_at"], str)


### PR DESCRIPTION
### Motivation

- Tests and schema expected a single, stable manifest shape including `pipeline_version`, stage fingerprints, counts, and timestamp, but the implementation accidentally duplicated `pipeline_version` and the serialized contract was not explicitly asserted in tests.
- The repository needs a small, explicit contract test to lock the serialized manifest keys and types as a stable API for downstream consumers.

### Description

- Fixed `ReproducibilityManifest` and `build_manifest()` by removing the accidental duplicate `pipeline_version` declaration/assignment and preserving the intended manifest shape (`pipeline_version`, `input_hashes`, `toolchain_versions`, `output_file_hashes`, `ingest_fingerprint`, `normalize_fingerprint`, `emit_fingerprint`, `query_count`, `module_count`, `generated_at`).
- Added a contract test `test_manifest_serialized_contract_keys_and_types` that validates the serialized manifest keys and value types, and tightened fingerprint assertions in `test_pipeline_roundtrip` to require 64-character SHA-256 digests.
- Updated the CUE manifest schema `src/pydantree/cue/manifest_schema.cue` to match the implemented manifest shape and make the fingerprint/count/version fields required.
- Adjusted CLI wiring and integration test usage so `_dispatch()` is invoked with a `WorkshopEventLogger` and `run_id`, and fixed the ingest staging path behavior to use the canonical stage file layout; updated README and ROADMAP wording to document the final manifest keys.

### Testing

- Ran `pytest tests/test_codegen_pipeline.py tests/test_codegen_cli_integration.py tests/unit/test_doctor.py` and all tests passed (12 passed).
- The new contract test and the tightened fingerprint checks executed successfully under the above test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e1aae52948333a1319e525c2039ae)